### PR TITLE
Fix Hebrew date format.

### DIFF
--- a/tex/hebrewcal.sty
+++ b/tex/hebrewcal.sty
@@ -1,5 +1,5 @@
 \ProvidesPackage{hebrewcal}
-        [2012/04/29 v2.5 %
+        [2015/04/17 v2.6 %
          Hebrew calendar for polyglossia (adapted from hebcal.sty in Babel)]
 \RequirePackage{xkeyval}
 \RequirePackage{bidi}
@@ -38,20 +38,20 @@
 \def\HebrewYearName#1{{%
    \@tempcnta=#1\divide\@tempcnta by 1000\multiply\@tempcnta by 1000
    \ifnum#1=\@tempcnta\relax % divisible by 1000: disambiguate
-     \hebrewnumeral{#1}\ (לפ"ג)%
+     \Hebrewnumeral{#1}\ (לפ"ג)%
    \else % not divisible by 1000
      \ifnum#1<1000\relax     % first millennium: disambiguate
-       \hebrewnumeral{#1}\ (לפ"ג)%
+       \Hebrewnumeral{#1}\ (לפ"ג)%
      \else 
        \ifnum#1<5000
-         \hebrewnumeral{#1}%
+         \Hebrewnumeral{#1}%
        \else
          \ifnum#1<6000 % current millenium, print without thousands
            \@tempcnta=#1\relax
            \if@hebrew@fullyear\else\advance\@tempcnta by -5000\fi
-           \hebrewnumeral{\@tempcnta}%
+           \Hebrewnumeral{\@tempcnta}%
          \else % #1>6000
-           \hebrewnumeral{#1}%
+           \Hebrewnumeral{#1}%
          \fi
        \fi
      \fi
@@ -81,7 +81,7 @@
         \fi%
     \fi}
 \def\@FormatForHebrew#1#2#3{%
-  \hebrewnumeral{#1}~ב\HebrewMonthName{#2}{#3}~%
+  \Hebrewnumeral{#1}~ב\HebrewMonthName{#2}{#3}~%
   \HebrewYearName{#3}}
 \def\HebrewMonthNameInEnglish#1#2{%
     \ifnum #1 = 7%


### PR DESCRIPTION
Day number and year should be written with Geresh and Gershayim
according to the rules of the [Academy of the Hebrew Language][1].

[1]: http://hebrew-academy.org.il/2012/07/31/%D7%AA%D7%90%D7%A8%D7%99%D7%9A-%D7%91%D7%97%D7%95%D7%93%D7%A9/

See also the following images: The correct one it the top one, while the other is incorrect.
![heb-date-correct](https://cloud.githubusercontent.com/assets/1255135/7198433/f6aa0256-e4f4-11e4-85d6-25ca8ee07132.png)
![heb-date-wrong](https://cloud.githubusercontent.com/assets/1255135/7198434/f6ab6d1c-e4f4-11e4-8389-dd1d6d0d94d8.png)

