### PR TITLE
Fix whitespace in German ldf-file

### DIFF
--- a/tex/gloss-german.ldf
+++ b/tex/gloss-german.ldf
@@ -207,22 +207,22 @@
   \ifgerman@latesthyphen
     \if@german@oldspelling
         \if@swiss@locale
-            \xpg@set@language@luatex@ii{swissgerman}
+            \xpg@set@language@luatex@ii{swissgerman}%
         \else
-            \xpg@set@language@luatex@ii{german-x-latest}
+            \xpg@set@language@luatex@ii{german-x-latest}%
         \fi
     \else
-        \xpg@set@language@luatex@ii{ngerman-x-latest}
+        \xpg@set@language@luatex@ii{ngerman-x-latest}%
     \fi
   \else% (latesthyphen=false)
     \if@german@oldspelling
         \if@swiss@locale
-            \xpg@set@language@luatex@ii{swissgerman}
+            \xpg@set@language@luatex@ii{swissgerman}%
         \else
-            \xpg@set@language@luatex@ii{german}
+            \xpg@set@language@luatex@ii{german}%
         \fi
     \else
-        \xpg@set@language@luatex@ii{ngerman}
+        \xpg@set@language@luatex@ii{ngerman}%
     \fi
   \fi
 }


### PR DESCRIPTION
The whitespace was introduced with commit cbc02fdb which cleaned up some if/else-constructs while introducing Swiss-German.

I am not firm with the internals of polyglossia, but my quick tests confirmed this code change to be the fix for whitespace-issues I had.

Best regards,
Pit.