### PR TITLE
Fix non breakable spaces for guillemets.

### DIFF
--- a/tex/gloss-french.ldf
+++ b/tex/gloss-french.ldf
@@ -49,8 +49,8 @@
   %   \XeTeXinterchartoks \z@ \french@punctguillstart = {\nobreakspace}% "a«" unchanged?
   %   \XeTeXinterchartoks \french@punctguillend \z@ = {\nobreakspace}% "»a" unchanged?
       \XeTeXinterchartoks \z@ \french@punctguillend = {\nobreakspace}% "a»" -> "a »"
-      \XeTeXinterchartoks \french@punctguillstart 255 = {\nobreakspace\xpg@nospace}% "«  " -> "«~"
-      \XeTeXinterchartoks 255 \french@punctguillend = {\xpg@unskip\nobreakspace}% "  »" -> "~»"
+  %   \XeTeXinterchartoks \french@punctguillstart 255 = {\nobreakspace\xpg@nospace}% "«  " -> "«~"
+  %   \XeTeXinterchartoks 255 \french@punctguillend = {\xpg@unskip\nobreakspace}% "  »" -> "~»"
       \XeTeXinterchartoks \french@punctguillend \french@punctthin = {\nobreak\thinspace}% "»;" -> "» ;"
       \XeTeXinterchartoks \french@punctguillend \french@punctthick = {\nobreakspace}% "»:" -> "» :"
       \XeTeXinterchartoks \french@punctthin \french@punctguillend  = {\nobreakspace}% "?»" -> "? »"

--- a/tex/gloss-french.ldf
+++ b/tex/gloss-french.ldf
@@ -135,5 +135,24 @@
 \def\inlineextras@french{%
    \french@punctuation%
    }
+   
+\def\ier{\textsuperscript{er}}
+\def\iers{\textsuperscript{ers}}
+\def\iere{\textsuperscript{re}}
+\def\ieres{\textsuperscript{res}}
+\def\ieme{\textsuperscript{e}}
+\def\iemes{\textsuperscript{es}}
+\def\nd{\textsuperscript{nd}}
+\def\nds{\textsuperscript{nds}}
+\def\nde{\textsuperscript{nde}}
+\def\ndes{\textsuperscript{ndes}}
+\def\no{\textsuperscript{o}}
+\def\nos{\textsuperscript{os}}
+
+\def\mme{M\textsuperscript{me}\space}
+\def\mmes{M\textsuperscript{mes}\space}
+\def\mr{M.\space}
+\def\mrs{MM.\space}
+
 
 \endinput

--- a/tex/gloss-french.ldf
+++ b/tex/gloss-french.ldf
@@ -154,6 +154,8 @@
 \def\mr{M.\space}
 \def\mrs{MM.\space}
 
+\ifx\@makefntext\undefined\else
 \renewcommand\@makefntext[1]{\quad\@thefnmark.\space #1}
+\fi
 
 \endinput

--- a/tex/gloss-french.ldf
+++ b/tex/gloss-french.ldf
@@ -154,5 +154,6 @@
 \def\mr{M.\space}
 \def\mrs{MM.\space}
 
+\renewcommand\@makefntext[1]{\quad\@thefnmark.\space #1}
 
 \endinput


### PR DESCRIPTION
When I use polyglossia in French, it messes up the guillemets' spaces when the input source already set the spaces.

Example:

```
    \usepackage{polyglossia}
    \setmainlanguage{french}
...
Ceci est «~la citation entre guillemets~».
```

Would produce 

![capture d ecran de 2015-10-31 12-17-51](https://cloud.githubusercontent.com/assets/1629771/10863320/8c4cd634-7fc9-11e5-8fca-fd33618b9783.png)

with the fix provided here, it will produce

![capture d ecran de 2015-10-31 12-18-14](https://cloud.githubusercontent.com/assets/1629771/10863322/9bed7b7a-7fc9-11e5-8c24-56528ee78867.png)
