### PR TITLE
Do not display a dot if the footnotemark is empty

### DIFF
--- a/tex/gloss-french.ldf
+++ b/tex/gloss-french.ldf
@@ -155,7 +155,7 @@
 \def\mrs{MM.\space}
 
 \ifx\@makefntext\undefined\else
-\renewcommand\@makefntext[1]{\quad\@thefnmark.\space #1}
+\renewcommand\@makefntext[1]{\quad\ifx\@thefnmark\empty\else\@thefnmark.\space\fi #1}
 \fi
 
 \endinput


### PR DESCRIPTION
This commit aims at correcting French style footnotes when a footnote
does not have a footnote mark (like a number). Without this commit,
special footnotes without a footnotemark would begin with a dot and a
space. For instance, the date in the `amsart` documentclass is printed
in a footnote and would be displayed as “ . Date : ...“. This commits
will check if the footnotemark isn't empty before appending a dot and a
space after it.