### PR TITLE
gloss-magyar.ldf enhancements

### DIFF
--- a/tex/gloss-magyar.ldf
+++ b/tex/gloss-magyar.ldf
@@ -5,6 +5,14 @@
   fontsetup=true,
 }
 
+% change 'táblázat x.x' to 'x.x. táblázat'
+\def\@@magyar@fnum@table{\thetable.~\tablename}
+\let\fnum@table\@@magyar@fnum@table
+
+% change 'ábra x.x' to 'x.x. ábra'
+\def\@@magyar@fnum@figure{\thefigure.~\figurename}
+\let\fnum@figure\@@magyar@fnum@figure
+
 \def\captionsmagyar{%
    \def\refname{Hivatkozások}%
    \def\abstractname{Kivonat}%

--- a/tex/gloss-magyar.ldf
+++ b/tex/gloss-magyar.ldf
@@ -5,6 +5,8 @@
   fontsetup=true,
 }
 
+\frenchspacing
+
 % change 'táblázat x.x' to 'x.x. táblázat'
 \def\@@magyar@fnum@table{\thetable.~\tablename}
 \let\fnum@table\@@magyar@fnum@table

--- a/tex/gloss-magyar.ldf
+++ b/tex/gloss-magyar.ldf
@@ -8,12 +8,12 @@
 \frenchspacing
 
 % change 'táblázat x.x' to 'x.x. táblázat'
-\def\@@magyar@fnum@table{\thetable.~\tablename}
-\let\fnum@table\@@magyar@fnum@table
+\newcommand{\@magyar@fnum@table}{\thetable.~\tablename}
+\let\fnum@table\@magyar@fnum@table
 
 % change 'ábra x.x' to 'x.x. ábra'
-\def\@@magyar@fnum@figure{\thefigure.~\figurename}
-\let\fnum@figure\@@magyar@fnum@figure
+\newcommand{\@magyar@fnum@figure}{\thefigure.~\figurename}
+\let\fnum@figure\@magyar@fnum@figure
 
 \def\captionsmagyar{%
    \def\refname{Hivatkozások}%


### PR DESCRIPTION
First patch fixes caption handling of figures and tables in hungarian, second one makes \frenchspacing default, as hungarian typography does not use double spaces.
