### PR TITLE
Implement "/ shortcut for German

### DIFF
--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -444,6 +444,7 @@ The default value of each option is given in italic.
 		\item ¦"~¦ for a compound word mark without a breakpoint
 		\item ¦"=¦ for a compound word mark with a breakpoint,
 			allowing hyphenation in the composing words.
+		\item ¦"/¦ a slash that allows for a line break and maintains hyphenation points.
 		\end{itemize}
 
 		There are also four shorthands for quotation signs:

--- a/tex/gloss-german.ldf
+++ b/tex/gloss-german.ldf
@@ -113,6 +113,8 @@
   \declare@shorthand{german}{""}{\hskip\z@skip}%
   \declare@shorthand{german}{"~}{\textormath{\leavevmode\hbox{-}}{-}}%
   \declare@shorthand{german}{"=}{\penalty\@M-\hskip\z@skip}%
+  \declare@shorthand{german}{"/}{\textormath
+    {\bbl@allowhyphens\discretionary{/}{}{/}\bbl@allowhyphens}{}}%
   \def\ck{\allowhyphens\discretionary{k-}{k}{ck}\allowhyphens}%
 }
 


### PR DESCRIPTION
I have added the same to babel-german in v. 2.9 (just submitted to CTAN).

I suggest to add it to Polyglossia as well. The shortcut produces a breakable slash, as opposed to `\slash`, however, it maintains hyphenation points, which is quite sensible for German.

The implementation is identical to the one in `gloss-dutch.ldf`.