### PR TITLE
French footnotes

### DIFF
--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -408,14 +408,11 @@ The default value of each option is given in italic.
   \item \Cmd\aemph (see section \ref{arabic}).
 	\end{itemize}
 
-%\subsection{french}\label{french}
-%\textbf{Options}:
-%	\begin{itemize}
-%    \item \TB{espacedeuxpoints} = thick or half \new{v1.2.x} ???
-%  \footnote{ %
-%    Can be customized by redefining \french@colonspace }
-%	\end{itemize}
-%
+\subsection{frenche}\label{french}\new{v1.5.0}
+\textbf{Options}:
+	\begin{itemize}
+		\item \TB{frenchfootnote} = true or \textit{false} (default value = true, wether the footnote mark inside footnote is normal script followed by a dot (default value) or uperscript without dot (false value))
+	\end{itemize}
 
 \subsection{german}\label{german}
 \textbf{Options}:

--- a/tex/gloss-french.ldf
+++ b/tex/gloss-french.ldf
@@ -155,7 +155,7 @@
 \def\mrs{MM.\space}
 
 \ifx\@makefntext\undefined\else
-\renewcommand\@makefntext[1]{\quad\ifx\@thefnmark\empty\else\@thefnmark.\space\fi #1}
+\renewcommand\@makefntext[1]{\parindent1em \noindent\quad\ifx\@thefnmark\empty\else\@thefnmark.\space\fi #1}
 \fi
 
 \endinput

--- a/tex/gloss-french.ldf
+++ b/tex/gloss-french.ldf
@@ -22,6 +22,21 @@
 \def\xpg@unskip{\ifhmode\ifdim\lastskip>\z@\unskip\fi\fi}
 \def\xpg@nospace#1{#1}
 
+\ifx\@makefntext\undefined\else
+  \let\nofrench@makefntext\@makefntext
+  \long\def\french@makefntext#1{\parindent1em \noindent\quad\ifx\@thefnmark\empty\else\@thefnmark.\space\fi #1}
+  \let\@makefntext\french@makefntext
+  \define@boolkey{french}[french@]{frenchfootnote}[true]{%
+  	\def\@tmpa{#1}
+    \def\@tmptrue{true}
+    \ifx\@tmpa\@tmptrue
+    	\let\@makefntext\french@makefntext
+		\else 
+			\let\@makefntext\nofrench@makefntext
+    \fi
+  }
+\fi
+
 \def\french@punctuation{%
     \lccode"2019="2019
     \ifluatex
@@ -154,8 +169,9 @@
 \def\mr{M.\space}
 \def\mrs{MM.\space}
 
-\ifx\@makefntext\undefined\else
-\renewcommand\@makefntext[1]{\parindent1em \noindent\quad\ifx\@thefnmark\empty\else\@thefnmark.\space\fi #1}
-\fi
+
+
+
+
 
 \endinput


### PR DESCRIPTION
This pull request:
- fix bug with indentation of paragraph in French footnotes-
- add a option to french setting `frenchfootnote=false` to come back to the default behavior, eg. having footnotemark in superscript and not in normalscript.

Cf #157