### PR TITLE
fix bug with part name in table of contents in French

### DIFF
--- a/tex/gloss-french.ldf
+++ b/tex/gloss-french.ldf
@@ -104,7 +104,7 @@
    Douzième\or Treizième\or Quatorzième\or Quinzième\or
    Seizième\or Dix-septième\or Dix-huitième\or Dix-neuvième\or
    Vingtième\fi\space}%
-   \def\thepart{\protect\@Fpt partie}%
+   \def\thepart{\@Fpt partie}%
    \def\partname{}%
    \def\pagename{page}%
    \def\seename{\emph{voir}}%

--- a/tex/gloss-french.ldf
+++ b/tex/gloss-french.ldf
@@ -104,8 +104,8 @@
    Douzième\or Treizième\or Quatorzième\or Quinzième\or
    Seizième\or Dix-septième\or Dix-huitième\or Dix-neuvième\or
    Vingtième\fi\space}%
-   \def\thepart{}%
-   \def\partname{\protect\@Fpt partie}%
+   \def\thepart{\protect\@Fpt partie}%
+   \def\partname{}%
    \def\pagename{page}%
    \def\seename{\emph{voir}}%
    \def\alsoname{\emph{voir aussi}}%


### PR DESCRIPTION
Before this commit, the part number was not printed in the toc (in french)