### PR TITLE
multiple corrections for French

### DIFF
--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -411,8 +411,8 @@ The default value of each option is given in italic.
 \subsection{french}\label{french}\new{v1.5.0}
 \textbf{Options}:
 	\begin{itemize}
-		\item \TB{automaticspacesaroundguillemets} = true or \textit{false} (default value = true. Should we add space after the opening guillemets and before the closing guillemets. Normally, you should not have such space in your source code, and you should let polyglossia adding it. If you have these in your source code, set the option to false)
-		\item \TB{frenchfootnote} = true or \textit{false} (default value = true, wether the footnote mark inside footnote is normal script followed by a dot (default value) or uperscript without dot (false value))
+		\item \TB{automaticspacesaroundguillemets} = true or \textit{false} (default value = true. Adds space after the opening guillemets and before the closing guillemets. Such space is usually not typed in source code, and you should let polyglossia add it. However, if your source code contains such space, you can set this option to false.)
+		\item \TB{frenchfootnote} = true or \textit{false} (default value = true. Determines whether the footnote mark starting the footnote is normal script followed by a dot (default) or superscript without a dot.)
 	\end{itemize}
 
 \subsection{german}\label{german}

--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -408,7 +408,7 @@ The default value of each option is given in italic.
   \item \Cmd\aemph (see section \ref{arabic}).
 	\end{itemize}
 
-\subsection{frenche}\label{french}\new{v1.5.0}
+\subsection{french}\label{french}\new{v1.5.0}
 \textbf{Options}:
 	\begin{itemize}
 		\item \TB{frenchfootnote} = true or \textit{false} (default value = true, wether the footnote mark inside footnote is normal script followed by a dot (default value) or uperscript without dot (false value))

--- a/tex/gloss-french.ldf
+++ b/tex/gloss-french.ldf
@@ -43,14 +43,14 @@
       \XeTeXcharclass `\› \french@punctguillend
       \XeTeXinterchartoks \z@ \french@punctthin = {\nobreak\thinspace}%
       \XeTeXinterchartoks \z@ \french@punctthick = {\nobreakspace}%
-      \XeTeXinterchartoks 255 \french@punctthin = {\xpg@unskip\nobreak\thinspace}%
-      \XeTeXinterchartoks 255 \french@punctthick = {\xpg@unskip\nobreakspace}%
+      \XeTeXinterchartoks \xpg@boundaryclass \french@punctthin = {\xpg@unskip\nobreak\thinspace}%
+      \XeTeXinterchartoks \xpg@boundaryclass \french@punctthick = {\xpg@unskip\nobreakspace}%
       \XeTeXinterchartoks \french@punctguillstart \z@ = {\nobreakspace}% "«a" -> "« a"
   %   \XeTeXinterchartoks \z@ \french@punctguillstart = {\nobreakspace}% "a«" unchanged?
   %   \XeTeXinterchartoks \french@punctguillend \z@ = {\nobreakspace}% "»a" unchanged?
       \XeTeXinterchartoks \z@ \french@punctguillend = {\nobreakspace}% "a»" -> "a »"
-  %   \XeTeXinterchartoks \french@punctguillstart 255 = {\nobreakspace\xpg@nospace}% "«  " -> "«~"
-  %   \XeTeXinterchartoks 255 \french@punctguillend = {\xpg@unskip\nobreakspace}% "  »" -> "~»"
+  %   \XeTeXinterchartoks \french@punctguillstart \xpg@boundaryclass = {\nobreakspace\xpg@nospace}% "«  " -> "«~"
+  %   \XeTeXinterchartoks \xpg@boundaryclass \french@punctguillend = {\xpg@unskip\nobreakspace}% "  »" -> "~»"
       \XeTeXinterchartoks \french@punctguillend \french@punctthin = {\nobreak\thinspace}% "»;" -> "» ;"
       \XeTeXinterchartoks \french@punctguillend \french@punctthick = {\nobreakspace}% "»:" -> "» :"
       \XeTeXinterchartoks \french@punctthin \french@punctguillend  = {\nobreakspace}% "?»" -> "? »"

--- a/tex/gloss-french.ldf
+++ b/tex/gloss-french.ldf
@@ -53,7 +53,7 @@
     \ifluatex
       \global\xpg@frpt=1\relax %
       \directlua{polyglossia.activate_frpt()}%
-    \else     
+    \else
       \XeTeXinterchartokenstate=1
       \XeTeXcharclass `\! \french@punctthin
       \XeTeXcharclass `\? \french@punctthin
@@ -191,10 +191,5 @@
 \def\mmes{M\textsuperscript{mes}\space}
 \def\mr{M.\space}
 \def\mrs{MM.\space}
-
-
-
-
-
 
 \endinput

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -26,6 +26,11 @@
   \RequireLuaModule{polyglossia}
 \fi
 
+% Which version of XeTeX do we use? What is the boudary class? 4095 or 255
+\@ifundefined{e@alloc@intercharclass@top}
+  {\chardef\xpg@boundaryclass=\@cclv}
+  {\let\xpg@boundaryclass=\e@alloc@intercharclass@top}
+
 % Useful for getting list of loaded languages and variants. Like babel's bbl@loaded
 \let\xpg@loaded\@empty
 \let\xpg@vloaded\@empty


### PR DESCRIPTION
This PR fix some problem in French:
- fix the problem for #96 of double punct sign in brackets
- fix the pb #157:
  - fix bug with indentation of paragraph in French footnotes
  - add a option to french setting frenchfootnote=false to come back to the default behavior, eg. having footnotemark in superscript and not in normalscript.
- Fix bug with the "part" title in the table of contents 
- Add compatibility with new version of XeTeX (#145)
- Restore normal behavior of spacing around guillemets (#141) but allow to not automatically insert space if needed by the input file.