### PR TITLE
clarified documentation for Sanskrit

### DIFF
--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -556,9 +556,13 @@ enable hyphenation when writing English within Korean text.
 	The value is passed to \pkg{fontspec} in cases where ¦\sanskritfont¦ or
 	¦\devanagarifont¦ are not defined. This can be useful if you typeset
 	Sanskrit texts in scripts other than Devanagari.
-  %TODO \item Numerals <<<<
+	  %TODO \item Numerals <<<<
 	\end{itemize}
-
+  \pkg{polyglossia} currently supports the typesetting of Sanskrit in the
+  following writing systems: Devanagari, Gujarati, Malayalam, Bengali, Kannada,
+  Telugu, and Latin.  Use the ¦Script=¦ option to select the writing system 
+  you want, and enter your input in that script.
+ 
 \subsection{serbian}\label{serbian}
 \textbf{Options}:
 	\begin{itemize}

--- a/tex/gloss-sanskrit.ldf
+++ b/tex/gloss-sanskrit.ldf
@@ -36,6 +36,11 @@
 \def\fontsetup@sanskrit@Telugu{%
   \def\xpg@scripttag@sanskrit{telu}%
   \xpg@fontsetup@nonlatin{sanskrit}}
+%% DW
+\def\fontsetup@sanskrit@Latin{%
+    \def\xpg@scripttag@sanskrit{latn}%
+    \xpg@fontsetup@latin{sanskrit}}
+%% DW
 
 \setkeys{sanskrit}{Script} %sets the default for Devanagari
 


### PR DESCRIPTION
I added Latin as a script option for Sanskrit, and clarified the documentation for Sanskrit slightly.  Let me know if you agree with this, if I've made a mistake, etc. 