### PR TITLE
Local activation of French punctuation spacing in LuaLaTeX

### DIFF
--- a/tex/gloss-french.ldf
+++ b/tex/gloss-french.ldf
@@ -72,7 +72,7 @@
 \def\french@punctuation{%
     \lccode"2019="2019
     \ifluatex
-      \global\xpg@frpt=1\relax %
+      \xpg@frpt=1\relax %
       \directlua{polyglossia.activate_frpt()}%
     \else
       \XeTeXinterchartokenstate=1
@@ -119,7 +119,7 @@
 \def\nofrench@punctuation{%
     \lccode"2019=\z@
     \ifluatex
-      \global\xpg@frpt=0\relax %
+      \xpg@frpt=0\relax %
       % Though it would make compilation slightly faster, it is not possible to
       % safely uncomment the following line. Imagine the following case: you start
       % a paragraph by some french text, then, in the same paragraph, you change


### PR DESCRIPTION
So far, the French language module of polyglossia enables the French spacing of punctuation globally within LuaLaTeX. So the spacing remains active even after the end of a French language environment. The French spacing should only be activated locally, so that it will not be in force after the end of the language environment.

Fixes #68, #153, #182, #201, and #227. However, the related issue #66 is not fixed.