### PR TITLE
Disable the extras of a language when a nested language starts

### DIFF
--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -975,6 +975,8 @@
 
 % Common code for `\select@language' and `\foreignlanguage'.
 \newcommand{\select@@language}[1]{%
+  % disable the extras of the previous language
+  \ifcsundef{languagename}{}{\noextrascurrent{\languagename}}
   \edef\languagename{#1}%
   \xpg@select@fontfamily{#1}%
   \csuse@warn{#1@language}%


### PR DESCRIPTION
Fixes: https://github.com/reutenauer/polyglossia/issues/66
Fixes: https://github.com/reutenauer/polyglossia/issues/169