### PR TITLE
Properly store \MakeUppercase and \@arabic for later restoration

### DIFF
--- a/tex/gloss-arabic.ldf
+++ b/tex/gloss-arabic.ldf
@@ -186,29 +186,36 @@ and may look very wrong.}
    \let\@alph\abjad%
    \let\@Alph\abjad%
 }
+
 \def\noarabic@numbers{%
   \let\@alph\latin@alph%
   \let\@Alph\latin@Alph%
-  }
+}
+
+% Store original definition
+\let\xpg@save@arabic\@arabic
 
 \def\arabic@globalnumbers{%
-  \let\orig@arabic\@arabic%
   \let\@arabic\arabicnumber%
   \renewcommand\thefootnote{\protect\arabicnumber{\c@footnote}}%
-  }
+}
 
 \def\noarabic@globalnumbers{
-   \let\@arabic\orig@arabic%
+   \let\@arabic\xpg@save@arabic%
    \renewcommand\thefootnote{\protect\number{\c@footnote}}%
-   }
+}
+
+% Save original \MakeUppercase definition
+\let\xpg@save@MakeUppercase\MakeUppercase
 
 \def\blockextras@arabic{%
-   \let\orig@MakeUppercase\MakeUppercase%
    \def\MakeUppercase##1{##1}%
    % TODO disable \@Roman and \@roman ?
-   }
+}
+
 \def\noextras@arabic{%
-   \let\MakeUppercase\orig@MakeUppercase%
-   }
+   % restore original \MakeUppercase definition
+   \let\MakeUppercase\xpg@save@MakeUppercase
+}
 
 \endinput

--- a/tex/gloss-divehi.ldf
+++ b/tex/gloss-divehi.ldf
@@ -40,12 +40,16 @@ and may look very wrong.}
 %   }
 %\def\datedivehi{\def\today{<++>}}
 
+% Save original \MakeUppercase definition
+\let\xpg@save@MakeUppercase\MakeUppercase
+
 \def\blockextras@divehi{%
-   \let\@@MakeUppercase\MakeUppercase%
    \def\MakeUppercase##1{##1}%
-   }
+}
+
 \def\noextras@divehi{%
-   \let\MakeUppercase\@@MakeUppercase%
-   }
+   % restore original \MakeUppercase definition
+   \let\MakeUppercase\xpg@save@MakeUppercase%
+}
 
 \endinput

--- a/tex/gloss-farsi.ldf
+++ b/tex/gloss-farsi.ldf
@@ -102,28 +102,35 @@ and may look very wrong.}
    \let\@alph\abjad%
    \let\@Alph\abjad%
 }
+
 \def\nofarsi@numbers{%
   \let\@alph\@latinalph%
   \let\@Alph\@latinAlph%
 }
 
 \def\farsi@globalnumbers{%
-   \let\orig@arabic\@arabic%
    \let\@arabic\farsinumber%
    % For some reason \thefootnote needs to be set separately:
    \renewcommand\thefootnote{\protect\farsinumber{\c@footnote}}%
-   }
+}
+
+% Store original definition
+\let\xpg@save@arabic\@arabic
 
 \def\nofarsi@globalnumbers{
-   \let\@arabic\orig@arabic%
+   \let\@arabic\xpg@save@arabic%
    \renewcommand\thefootnote{\protect\number{\c@footnote}}%
-   }
+}
+
+% Save original \MakeUppercase definition
+\let\xpg@save@MakeUppercase\MakeUppercase
 
 \def\blockextras@farsi{%
-   \let\@@MakeUppercase\MakeUppercase%
    \def\MakeUppercase##1{##1}%
-   }
+}
+
 \def\noextras@farsi{%
-   \let\MakeUppercase\@@MakeUppercase%
-   }
+   % restore original \MakeUppercase definition
+   \let\MakeUppercase\xpg@save@MakeUppercase
+}
 \endinput

--- a/tex/gloss-hebrew.ldf
+++ b/tex/gloss-hebrew.ldf
@@ -112,18 +112,22 @@ and may look very wrong.}
    \let\@alph\hebrewnumeral%
    \let\@Alph\Hebrewnumeral%
 }
+
 \def\nohebrew@numbers{%
   \let\@alph\latin@alph%
   \let\@Alph\latin@Alph%
 }
 
 \def\hebrew@globalnumbers{%
-   \let\orig@arabic\@arabic%
    \let\@arabic\hebrewnumber%
    \renewcommand\thefootnote{\hebrewnumber{\c@footnote}}%
 }
+
+% Store original definition
+\let\xpg@save@arabic\@arabic
+
 \def\nohebrew@globalnumbers{%
-  \let\@arabic\orig@arabic%
+  \let\@arabic\xpg@save@arabic%
   \renewcommand\thefootnote{\@arabic\c@footnote}%
 }
 

--- a/tex/gloss-hindi.ldf
+++ b/tex/gloss-hindi.ldf
@@ -94,12 +94,16 @@ and may look very wrong.}
     \space\hindinumber\year}%
 }
 
+% Save original \MakeUppercase definition
+\let\xpg@save@MakeUppercase\MakeUppercase
+
 \def\blockextras@hindi{%
-  \let\@@MakeUppercase\MakeUppercase%
   \def\MakeUppercase##1{##1}%
 }
+
 \def\noextras@hindi{%
-  \let\MakeUppercase\@@MakeUppercase%
+   % restore original \MakeUppercase definition
+   \let\MakeUppercase\xpg@save@MakeUppercase%
 }
 
 \endinput

--- a/tex/gloss-syriac.ldf
+++ b/tex/gloss-syriac.ldf
@@ -137,26 +137,35 @@ and may look very wrong.}
    \let\@alph\abjadsyriac%
    \let\@Alph\abjadsyriac%
 }
+
 \def\nosyriac@numbers{%
   \let\@alph\latin@alph%
   \let\@Alph\latin@Alph%
-  }
+}
+
+% Store original definition
+\let\xpg@save@arabic\@arabic
+
 \def\syriac@globalnumbers{%
-  \let\orig@arabic\@arabic%
   \let\@arabic\syriacnumber%
   \renewcommand\thefootnote{\protect\syriacnumber{\c@footnote}}%
 }
+
 \def\nosyriac@globalnumbers{%
-  \let\@arabic\orig@arabic%
+  \let\@arabic\xpg@save@arabic%
   \renewcommand\thefootnote{\protect\number{\c@footnote}}%
-  }
+}
+
+% Save original \MakeUppercase definition
+\let\xpg@save@MakeUppercase\MakeUppercase
 
 \def\blockextras@syriac{%
-   \let\@@MakeUppercase\MakeUppercase%
    \def\MakeUppercase##1{##1}%
-   }
+}
+
 \def\noextras@syriac{%
-   \let\MakeUppercase\@@MakeUppercase%
-   }
+   % restore original \MakeUppercase definition
+   \let\MakeUppercase\xpg@save@MakeUppercase%
+}
 
 \endinput

--- a/tex/gloss-urdu.ldf
+++ b/tex/gloss-urdu.ldf
@@ -110,33 +110,38 @@ and may look very wrong.}
 \def\urdu@numbers{%
   \let\@alph\abjad%
   \let\@Alph\abjad%
-  }
+}
 
 \def\nourdu@numbers{%
   \let\@alph\latin@alph%
   \let\@Alph\latin@Alph%
-  }
+}
+
+% Store original definition
+\let\xpg@save@arabic\@arabic
 
 \def\urdu@globalnumbers{%
-  \let\orig@arabic\@arabic%
   \let\@arabic\urdunumber%
   % For some reason \thefootnote needs to be set separately:
   \renewcommand\thefootnote{\protect\urdunumber{\c@footnote}}%
-  }
+}
 
 \def\nourdu@globalnumbers{
-  \let\@arabic\orig@arabic%
+  \let\@arabic\xpg@save@arabic%
   \renewcommand\thefootnote{\protect\number{\c@footnote}}%
-  }
+}
+
+% Save original \MakeUppercase definition
+\let\xpg@save@MakeUppercase\MakeUppercase
 
 \def\blockextras@urdu{%
-  \let\@@MakeUppercase\MakeUppercase%
   \def\MakeUppercase##1{##1}%
-  }
+}
 
 \def\noextras@urdu{%
-  \let\MakeUppercase\@@MakeUppercase%
-  }
+   % restore original \MakeUppercase definition
+   \let\MakeUppercase\xpg@save@MakeUppercase%
+}
 
 \endinput
 


### PR DESCRIPTION
This amends https://github.com/reutenauer/polyglossia/commit/d535005c64277a323ceedad049170038df0b7494