### PR TITLE
Remove \leavevmode's

### DIFF
--- a/tests/luatex/test-issue-204.tex
+++ b/tests/luatex/test-issue-204.tex
@@ -1,0 +1,32 @@
+% !TeX TS-program = lualatex
+% See https://github.com/reutenauer/polyglossia/issues/204
+\documentclass{article}
+
+\usepackage{fontspec}
+\setmainfont{EB Garamond}
+\newfontfamily\arabicfont{Scheherazade}[Script=Arabic,Scale=MatchUppercase]
+
+\usepackage{polyglossia}
+\setmainlanguage{english}
+\setotherlanguage{arabic}
+\setotherlanguage{french}
+
+\begin{document}
+
+\centering
+
+\foreignlanguage{french}{Bonjour.}
+
+Hello.
+
+\foreignlanguage{arabic}{مرحبا.} Wrong direction.
+
+\textarabic{مرحبا.}
+
+Hello.
+
+\textenglish{Hello.}
+
+Hello.
+
+\end{document}

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -833,7 +833,6 @@
 
 % wrapper for foreignlanguage and otherlanguage*
 \cs_new:Nn \polyglossia@setforeignlanguage:n {
-  \leavevmode
   \select@@language{#1}
 }
 
@@ -854,7 +853,6 @@
    \bgroup
    \xpg@otherlanguage[#1]{#2}%
    #3
-   \leavevmode
    \egroup
 }
 
@@ -875,7 +873,6 @@
    \xpg@otherlanguage[#1]{#2}%
    \csuse{date#2}%
    #3
-   \leavevmode
    \egroup
 }
 
@@ -1006,8 +1003,6 @@
 
 \renewenvironment{otherlanguage}[2][]
 {
-  % in order to get correct aligment of paragraph
-  \leavevmode
   \selectlanguage[#1]{#2}
 }
 {}


### PR DESCRIPTION
This is not needed (reutenauer/polyglossia#204 is still fixed) and it
breaks bidi detection at paragraph start.