### PR TITLE
Implement support for (French) canadien and (English) canadian

### DIFF
--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -408,7 +408,8 @@ The default value of each option is given in italic.
 \subsection{english}\label{english}
 \textbf{Options}:
 	\begin{itemize}
-	\item \TB{variant} = \textit{american} (= us), usmax (same as ‘american’ but with additional hyphenation patterns), british (= uk), australian or newzealand
+	\item \TB{variant} = \textit{american} (= us), usmax (same as ‘american’ but with additional hyphenation patterns),
+	british (= uk), australian, canadian\new{v1.45} or newzealand
 	\item \TB{ordinalmonthday} = true/\textit{false} (true by default only when variant = british)
 	\end{itemize}
 
@@ -434,6 +435,8 @@ The default value of each option is given in italic.
 \subsection{french}\label{french}\new{v1.5.0}
 \textbf{Options}:
 	\begin{itemize}
+		\item\TB{variant} = \textit{french} or canadian (=~acadian).\new{v1.45}
+		Currently, the three variants do not differ; they are supported for compatibility with \pkg{babel} (where they do not differ either).
 		\item \TB{automaticspacesaroundguillemets} = true or \textit{false} (default value = true. Adds space after the opening guillemets and before the closing guillemets. Such space is usually not typed in source code, and you should let polyglossia add it. However, if your source code contains such space, you can set this option to false.)
 		\item \TB{frenchfootnote} = true or \textit{false} (default value = true. Determines whether the footnote mark starting the footnote is normal script followed by a dot (default) or superscript without a dot.)
 		\item \TB{OriginalTypewriter} = true or \textit{false} (default value = false. Prevents any customisation of |\ttfamily| and |\texttt{}| in French. This option should only be used to ensure backward compatibility. The current default behaviour is to switch off.)

--- a/tex/gloss-english.ldf
+++ b/tex/gloss-english.ldf
@@ -19,7 +19,7 @@
 % Option ordinalmonthday
 \define@boolkey{english}[english@]{ordinalmonthday}[true]{}
 
-\define@choicekey*+{english}{variant}[\val\nr]{uk,british,us,american,usmax,australian,newzealand}{%
+\define@choicekey*+{english}{variant}[\val\nr]{uk,british,us,american,usmax,australian,newzealand,canadian}{%
    \ifcase\nr\relax
       % uk:
       \british@hyphentrue
@@ -72,6 +72,13 @@
       \british@dateformattrue
       \english@ordinalmonthdayfalse
       \xpg@info{Option: English, variant=newzealand}%
+   \or
+      % canadian:
+      % This is currently equivalent to usenglish (as in babel)
+      \british@hyphenfalse
+      \british@dateformatfalse
+      \english@ordinalmonthdayfalse
+      \xpg@info{Option: English, variant=american}%
    \fi
    \ifbritish@hyphen
       \xpg@ifdefined{ukenglish}{}%

--- a/tex/gloss-french.ldf
+++ b/tex/gloss-french.ldf
@@ -9,6 +9,31 @@
   hyphenmins={2,2},
   fontsetup=true}
 
+\def\french@variant{french}
+\define@choicekey*+{french}{variant}[\val\nr]{french,canadian,acadian}{%
+   \ifcase\nr\relax
+      % french:
+      \gdef\french@variant{french}%
+   \or
+      % canadian:
+      \gdef\french@variant{canadian}%
+   \or
+      % acadian:
+      \gdef\french@variant{canadian}%
+   \fi
+   \xpg@info{Option: French, variant=\val}%
+}{\xpg@warning{Unknown French variant `#1'}}
+
+
+\def\french@language{%
+   \ifxetex
+      \language=\csname l@\french@variant\endcsname
+   \fi
+   \ifluatex
+      \xpg@set@language@luatex@iv{\french@variant}
+   \fi
+}%
+
 \ifluatex
   \newluatexattribute\xpg@frpt %
   \directlua{polyglossia.load_frpt()}%
@@ -173,6 +198,7 @@
    \def\headtoname{}%
    \def\proofname{Démonstration}%
    }
+
 \def\datefrench{%
    \def\today{\ifx\ier\undefined\def\ier{er}\fi
       \ifnum\day=1\relax 1\ier%


### PR DESCRIPTION
on the same very basic level than babel. The rationale is parity with
babel here.

Fixes reutenauer/polyglossia#22