### PR TITLE
Correction of the Lua module for French

### DIFF
--- a/tex/polyglossia-frpt.lua
+++ b/tex/polyglossia-frpt.lua
@@ -19,10 +19,10 @@ local has_attribute      = node.has_attribute
 local node_copy          = node.copy
 local new_node           = node.new
 
+local math_code          = nodecodes.math
 local end_of_math        = node.end_of_math
 if not end_of_math then -- luatex < .76
   local traverse_nodes = node.traverse_id
-  local math_code      = nodecodes.math
   local end_of_math = function (n)
     for n in traverse_nodes(math_code, n.next) do
       return n


### PR DESCRIPTION
Fixes #92.
Skipping the insertion of French spaces within math mode did not work because a variable defined in an local environment was undefined outside. Now it is defined and the skipping works.