### PR TITLE
Correct spacing of closing French guillemet with XeTeX.

### DIFF
--- a/tex/gloss-french.ldf
+++ b/tex/gloss-french.ldf
@@ -128,9 +128,9 @@
       \XeTeXcharclass `\[ \french@closebrackets
       \XeTeXcharclass `\{ \french@openbrackets
       \XeTeXcharclass `\} \french@closebrackets
-      \XeTeXinterchartoks \z@ \french@punctthin = {\nobreak\thinspace}%
+      \XeTeXinterchartoks \z@ \french@punctthin = {\thinspace}%
       \XeTeXinterchartoks \z@ \french@punctthick = {\nobreakspace}%
-      \XeTeXinterchartoks \xpg@boundaryclass \french@punctthin = {\xpg@unskip\nobreak\thinspace}%
+      \XeTeXinterchartoks \xpg@boundaryclass \french@punctthin = {\xpg@unskip\thinspace}%
       \XeTeXinterchartoks \xpg@boundaryclass \french@punctthick = {\xpg@unskip\nobreakspace}%
       \iffrench@autospaceguillemets
         \XeTeXinterchartoks \french@punctguillstart \z@ = {\thinspace}% "«a" -> "«\,a"
@@ -140,12 +140,12 @@
         \XeTeXinterchartoks \french@punctguillstart \xpg@boundaryclass = {\thinspace\ignorespaces}% "«  " -> "«\,"
         \XeTeXinterchartoks \xpg@boundaryclass \french@punctguillend = {\xpg@unskip\thinspace}% "  »" -> "\,»"
      \fi
-     \XeTeXinterchartoks \french@punctguillend \french@punctthin = {\nobreak\thinspace}% "»;" -> "» ;"
+     \XeTeXinterchartoks \french@punctguillend \french@punctthin = {\thinspace}% "»;" -> "» ;"
      \XeTeXinterchartoks \french@punctguillend \french@punctthick = {\nobreakspace}% "»:" -> "» :"
-     \XeTeXinterchartoks \french@punctthin \french@punctguillend  = {\nobreakspace}% "?»" -> "? »"
+     \XeTeXinterchartoks \french@punctthin \french@punctguillend  = {\thinspace}% "?»" -> "?\,»"
      \XeTeXinterchartoks \french@openbrackets \french@punctthin = {\xpg@unskip}% "(?" -> "(?" and not "( ?"      
      \XeTeXinterchartoks \french@punctthin \french@closebrackets = {\xpg@unskip}% "?)" -> "?)" (code not need, just for symetry with previous one)
-     \XeTeXinterchartoks \french@closebrackets \french@punctthin = {\nobreak\thinspace}% ")?" -> ") ?"
+     \XeTeXinterchartoks \french@closebrackets \french@punctthin = {\thinspace}% ")?" -> ") ?"
      \XeTeXinterchartoks \french@closebrackets \french@punctthick = {\nobreakspace}% "):" -> ") :"
     \fi
     }

--- a/tex/gloss-french.ldf
+++ b/tex/gloss-french.ldf
@@ -140,12 +140,12 @@
         \XeTeXinterchartoks \french@punctguillstart \xpg@boundaryclass = {\thinspace\ignorespaces}% "«  " -> "«\,"
         \XeTeXinterchartoks \xpg@boundaryclass \french@punctguillend = {\xpg@unskip\thinspace}% "  »" -> "\,»"
      \fi
-     \XeTeXinterchartoks \french@punctguillend \french@punctthin = {\thinspace}% "»;" -> "» ;"
+     \XeTeXinterchartoks \french@punctguillend \french@punctthin = {\thinspace}% "»;" -> "»\,;"
      \XeTeXinterchartoks \french@punctguillend \french@punctthick = {\nobreakspace}% "»:" -> "» :"
      \XeTeXinterchartoks \french@punctthin \french@punctguillend  = {\thinspace}% "?»" -> "?\,»"
      \XeTeXinterchartoks \french@openbrackets \french@punctthin = {\xpg@unskip}% "(?" -> "(?" and not "( ?"      
      \XeTeXinterchartoks \french@punctthin \french@closebrackets = {\xpg@unskip}% "?)" -> "?)" (code not need, just for symetry with previous one)
-     \XeTeXinterchartoks \french@closebrackets \french@punctthin = {\thinspace}% ")?" -> ") ?"
+     \XeTeXinterchartoks \french@closebrackets \french@punctthin = {\thinspace}% ")?" -> ")\,?"
      \XeTeXinterchartoks \french@closebrackets \french@punctthick = {\nobreakspace}% "):" -> ") :"
     \fi
     }


### PR DESCRIPTION
This is an addition to #232.
#232 reduced the space after an opening guillemet and before a closing guillemet to a `\thinspace`. This is now also done for a closing guillemet after an exclamation mark or a question mark.
Furthermore `\thinspace` is defined as a kind of kern, so an additional `\nobreak` is not necessary.