### PR TITLE
suppress redundant warning when nohyphenation is specified

### DIFF
--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -273,7 +273,9 @@
       \xdef\xpg@lastlanguage{\the\csname l@#1\endcsname}%
     }{%
       \ifluatex%
-      \xpg@set@language@luatex@iv{#1}%
+        \cs_if_eq:cNF{l@#1}{\l@nohyphenation}{%
+          \xpg@set@language@luatex@iv{#1}%
+        }%
       \fi%
       \language=\csname l@#1\endcsname%
     }%


### PR DESCRIPTION
On luatex engine, without this patch we have many useless warnings like this:
```
Module polyglossia Warning: Language korean not found in language.dat.lua on in
put line 2
```
even when `hyphennames` of the language is expressly specifed as `nohyphenation`.