### PR TITLE
prevent warning related to gloss-latex and the others

### DIFF
--- a/tex/polyglossia.lua
+++ b/tex/polyglossia.lua
@@ -29,7 +29,7 @@ local polyglossia = polyglossia
 -- predefined l@nohyphenation or dummy new language
 local nohyphid = luatexbase.registernumber'l@nohyphenation' or lang.id(lang.new())
 -- key `nohyphenation` is for .sty file when possibly undefined l@nohyphenation
-polyglossia.newloader_loaded_languages = { nohyphenation = nohyphid }
+local newloader_loaded_languages = { nohyphenation = nohyphid }
 
 local newloader_available_languages = dofile(kpse.find_file('language.dat.lua'))
 -- Suggestion by Dohyun Kim on #129
@@ -97,14 +97,14 @@ local lang_register = 19
 
 -- New hyphenation pattern loader: use language.dat.lua directly and the language identifiers
 local function newloader(langentry)
-    loaded_language = polyglossia.newloader_loaded_languages[langentry]
+    local loaded_language = newloader_loaded_languages[langentry]
     if loaded_language then
         log_info('Language ' .. langentry .. ' already loaded; id is ' .. lang.id(loaded_language))
         -- texio.write_nl('term and log', 'Language ' .. langentry .. ' already loaded with patterns ' .. tostring(loaded_language) .. '; id is ' .. lang.id(loaded_language))
         -- texio.write_nl('term and log', 'Language ' .. langentry .. ' already loaded with patterns ' .. loaded_language['patterns'] .. '; id is ' .. lang.id(loaded_language))
         return lang.id(loaded_language)
     else
-        langdata = newloader_available_languages[langentry]
+        local langdata = newloader_available_languages[langentry]
         if langdata and langdata['special'] == 'language0' then return 0 end
 
         if langdata then
@@ -128,22 +128,22 @@ local function newloader(langentry)
 			s = s .. "\npatterns: " .. langdata.patterns
 			log_info(s)
             if langdata.patterns and langdata.patterns ~= '' then
-                pattfilepath = kpse.find_file(langdata.patterns)
+                local pattfilepath = kpse.find_file(langdata.patterns)
                 if pattfilepath then
-                    pattfile = io.open(pattfilepath)
+                    local pattfile = io.open(pattfilepath)
                     lang.patterns(langobject, pattfile:read('*all'))
                     pattfile:close()
                 end
             end
             if langdata.hyphenation and langdata.hyphenation ~= '' then
-                hyphfilepath = kpse.find_file(langdata.hyphenation)
+                local hyphfilepath = kpse.find_file(langdata.hyphenation)
                 if hyphfilepath then
-                    hyphfile = io.open(hyphfilepath)
+                    local hyphfile = io.open(hyphfilepath)
                     lang.hyphenation(langobject, hyphfile:read('*all'))
                     hyphfile:close()
                 end
             end
-            polyglossia.newloader_loaded_languages[langentry] = langobject
+            newloader_loaded_languages[langentry] = langobject
 
             log_info('Language ' .. langentry .. ' was not yet loaded; created with id ' .. lang.id(langobject))
             return lang.id(langobject)
@@ -161,6 +161,7 @@ polyglossia.check_char = check_char
 polyglossia.load_frpt = load_frpt
 polyglossia.load_tibt_eol = load_tibt_eol
 polyglossia.newloader = newloader
+polyglossia.newloader_loaded_languages = newloader_loaded_languages
 -- global variables:
 -- polyglossia.default_language
 -- polyglossia.current_language

--- a/tex/polyglossia.lua
+++ b/tex/polyglossia.lua
@@ -26,8 +26,12 @@ end
 polyglossia = polyglossia or {}
 local polyglossia = polyglossia
 
-polyglossia.newloader_loaded_languages = { }
-polyglossia.newloader_max_langid = 0
+-- predefined l@nohyphenation or dummy new language
+local nohyphid = luatexbase.registernumber'l@nohyphenation' or lang.id(lang.new())
+-- key `nohyphenation` is for .sty file when possibly undefined l@nohyphenation
+polyglossia.newloader_loaded_languages = { nohyphenation = nohyphid }
+-- newloader_max_langid will be increased one by one per language
+local newloader_max_langid = nohyphid
 local newloader_available_languages = dofile(kpse.find_file('language.dat.lua'))
 -- Suggestion by Dohyun Kim on #129
 local t = { }
@@ -106,10 +110,8 @@ local function newloader(langentry)
             for k, v in pairs(langdata) do
 				s = s .. "\n" .. k .. "\t" .. tostring(v)
             end
-            polyglossia.newloader_max_langid = polyglossia.newloader_max_langid + 1
-            -- langobject = lang.new(newloader_max_langid)
-            lang.new(); lang.new(); lang.new()
-            langobject = lang.new()
+            newloader_max_langid = newloader_max_langid + 1
+            langobject = lang.new(newloader_max_langid)
 			s = s .. "\npatterns: " .. langdata.patterns
 			log_info(s)
             if langdata.patterns and langdata.patterns ~= '' then
@@ -134,7 +136,7 @@ local function newloader(langentry)
             return lang.id(langobject)
         else
             log_warning('Language ' .. langentry .. ' not found in language.dat.lua')
-            return 255
+            return nohyphid
         end
     end
 end

--- a/tex/polyglossia.lua
+++ b/tex/polyglossia.lua
@@ -30,8 +30,8 @@ local polyglossia = polyglossia
 local nohyphid = luatexbase.registernumber'l@nohyphenation' or lang.id(lang.new())
 -- key `nohyphenation` is for .sty file when possibly undefined l@nohyphenation
 polyglossia.newloader_loaded_languages = { nohyphenation = nohyphid }
--- newloader_max_langid will be increased one by one per language
-local newloader_max_langid = nohyphid
+-- newloader_max_langid will be increased by 4 per language
+local newloader_max_langid = 0
 local newloader_available_languages = dofile(kpse.find_file('language.dat.lua'))
 -- Suggestion by Dohyun Kim on #129
 local t = { }
@@ -110,7 +110,7 @@ local function newloader(langentry)
             for k, v in pairs(langdata) do
 				s = s .. "\n" .. k .. "\t" .. tostring(v)
             end
-            newloader_max_langid = newloader_max_langid + 1
+            newloader_max_langid = newloader_max_langid + 4
             langobject = lang.new(newloader_max_langid)
 			s = s .. "\npatterns: " .. langdata.patterns
 			log_info(s)

--- a/tex/polyglossia.lua
+++ b/tex/polyglossia.lua
@@ -112,6 +112,21 @@ local function newloader(langentry)
             for k, v in pairs(langdata) do
 				s = s .. "\n" .. k .. "\t" .. tostring(v)
             end
+
+            --
+            -- LaTeX's \newlanguage increases language register (count19),
+            -- whereas LuaTeX's lang.new() increases its own language id.
+            -- So when a user has declared, say, \newlanguage\lang@xyz, then
+            -- these two numbers do not match each other. If we do not consider
+            -- this possible situation, our newloader() function will
+            -- unfortunately overwrite the language \lang@xyz.
+            --
+            -- Threfore here we will compare LaTeX's \newlanguage number with
+            -- LuaTeX's lang.new() id and select the bigger one for our new
+            -- language object. Also we will update LaTeX's language register
+            -- by this new id, so that another possible \newlanguage should not
+            -- overwrite our language object.
+            --
             -- get next \newlanguage allocation number
             local langcnt = tex.count[lang_register] + 1
             -- get new lang object

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -863,9 +863,15 @@
 \newXeTeXintercharclass\xpg@normalclass %TODO
 }{}
 
+\ifxetex
 %% when no patterns are available, we use \l@nohyphenation, assigned to 255
 %%  (suggestion by Enrico Gregorio)
-\@ifundefined{l@nohyphenation}{\chardef\l@nohyphenation=255 }{}
+  \@ifundefined{l@nohyphenation}{\chardef\l@nohyphenation=255 }{}
+\else\ifluatex
+  \@ifundefined{l@nohyphenation}{\chardef\l@nohyphenation=\directlua{
+    tex.sprint(polyglossia.newloader_loaded_languages.nohyphenation)}\relax
+  }{}
+\fi\fi
 
 %we call this macro when a gloss file is not found for a given language
 \def\xpg@nogloss#1{%
@@ -1222,7 +1228,7 @@
         \polyglossia@check@ifdefined:NF{#1}{
             \expandafter\chardef\csname l@#1\endcsname=\directlua{tex.sprint(polyglossia.newloader('#1'))}%
         }
-        \language\directlua{tex.sprint(polyglossia.newloader('#1'))}%
+        \language=\csname l@#1\endcsname
     \fi
 }
 


### PR DESCRIPTION
On luatex engine, currently a waning is emitted related to `gloss-latex.ldf`:
```
Module polyglossia Warning: Language latex not found in language.dat.lua on input line 8
```
This PR addresses it. Without this patch, language id of `latex` would become `255` (nohyphen) as returned by polyglossia.lua.

Incidentally, as LaTeX format already has defined `\l@nohyphenation`, we can use this in the lua module. Actually `255` is not a good id for nohyphen language, because in luatex the maximum language id is not 255 but 16383 (see luatex manual 5.2, p.68).