### PR TITLE
Add uppercase (alphanumeric) variant to localnumber

### DIFF
--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -732,16 +732,19 @@ or whatever is appropriate (see sec.~\ref{sec:localnumber}). The possibilities a
 
 \subsection{General localization of numbering}\label{sec:localnumber}
 
-As of 1.45,\new{1.45} \pkg{polyglossia} provides a generic macro \Cmd\Localnumber\ which converts numbers
+As of 1.45,\new{1.45} \pkg{polyglossia} provides a generic macro \Cmd\localnumber\ which converts numbers
 to the current local form (which might be script-specific decimal digit, an alphabetic numbering or something else).
 For instance in an Arabic environment
-¦\Localnumber{42}¦ yields \textarabic{\Localnumber{42}}, whereas in an Hebrew environment, it
-results in \texthebrew[numerals=hebrew]{\Localnumber{42}} with ¦numerals=hebrew¦, and \texthebrew{\Localnumber{42}}
+¦\localnumber{42}¦ yields \textarabic{\localnumber{42}}, whereas in an Hebrew environment, it
+results in \texthebrew[numerals=hebrew]{\localnumber{42}} with ¦numerals=hebrew¦, and \texthebrew{\localnumber{42}}
 with ¦numerals=arabic¦. Note that, as opposed to the various ¦digits¦ macros (described in sec.~\ref{sec:decdigit}),
 the argument of ¦\Localnumber¦ must consist of numbers only.
 
-For\new{1.45} the conversion of counters, a generic macro \Cmd\localnumber\ is provided. This takes a counter as argument.
-For instance in an Arabic environment ¦\localnumber{page}¦ yields \textarabic{\localnumber{page}}.
+For\new{1.45} the conversion of counters, the starred version \Cmd{\localnumber*} is provided. This takes a counter as argument.
+For instance in an Arabic environment ¦\localnumber*{page}¦ yields \textarabic{\localnumber*{page}}.
+
+For scripts with alphanumeric numbering, the uppercased variants \Cmd{\Localnumber} and \Cmd{\Localnumber*} provide the uppercased 
+versions.
 
 \subsection{Non-Western decimal digits}\label{sec:decdigit}
 

--- a/tex/gloss-arabic.ldf
+++ b/tex/gloss-arabic.ldf
@@ -201,8 +201,8 @@ and may look very wrong.}
 
 \def\arabic@globalnumbers{%
   \let\@arabic\arabicnumber%
-  \renewcommand\thefootnote{\localnumber{footnote}}%
-  \renewcommand\theequation{\localnumber{equation}}%
+  \renewcommand\thefootnote{\localnumber*{footnote}}%
+  \renewcommand\theequation{\localnumber*{equation}}%
 }
 
 \def\noarabic@globalnumbers{%

--- a/tex/gloss-bengali.ldf
+++ b/tex/gloss-bengali.ldf
@@ -131,7 +131,7 @@ and may look very wrong.}
 
 \def\bengali@globalnumbers{%
    \let\@arabic\bengalinumber%
-   \renewcommand\thefootnote{\localnumber{footnote}}%
+   \renewcommand\thefootnote{\localnumber*{footnote}}%
 }
 
 % Store original definition

--- a/tex/gloss-farsi.ldf
+++ b/tex/gloss-farsi.ldf
@@ -125,8 +125,8 @@ and may look very wrong.}
 
 \def\farsi@globalnumbers{%
    \let\@arabic\farsinumber%
-   \renewcommand\thefootnote{\localnumber{footnote}}%
-   \renewcommand\theequation{\localnumber{equation}}%
+   \renewcommand\thefootnote{\localnumber*{footnote}}%
+   \renewcommand\theequation{\localnumber*{equation}}%
 }
 
 % Store original definition

--- a/tex/gloss-greek.ldf
+++ b/tex/gloss-greek.ldf
@@ -6,7 +6,8 @@
   frenchspacing=true,
   indentfirst=true,
   fontsetup=true,
-  localnumber=greeknumerals
+  localnumber=greeknumerals,
+  Localnumber=Greeknumerals
   %TODO localalph={greek@alph,greek@Alph}
 }
 
@@ -240,6 +241,7 @@
 \anw@true
 
 \newcommand{\greeknumerals}[2]{\greeknumber{#2}}
+\newcommand{\Greeknumerals}[2]{\Greeknumber{#2}}
 
 \protected\def\greeknumber#1{\expandafter\@greeknumber\expandafter{\number#1}}
 \def\@greeknumber#1{%

--- a/tex/gloss-hebrew.ldf
+++ b/tex/gloss-hebrew.ldf
@@ -116,7 +116,7 @@ and may look very wrong.}
 
 \def\hebrew@globalnumbers{%
    \let\@arabic\hebrewnumber%
-   \renewcommand\thefootnote{\localnumber{footnote}}%
+   \renewcommand\thefootnote{\localnumber*{footnote}}%
 }
 
 % Store original definition

--- a/tex/gloss-khmer.ldf
+++ b/tex/gloss-khmer.ldf
@@ -84,7 +84,7 @@
 \def\khmer@globalnumbers{%
 	\let\orig@arabic\@arabic%
 	\let\@arabic\khmernumber%
-	\renewcommand{\thefootnote}{\localnumber{footnote}}%
+	\renewcommand{\thefootnote}{\localnumber*{footnote}}%
 }
 \def\nokhmer@globalnumbers{%
 	\let\@arabic\orig@arabic%
@@ -153,6 +153,6 @@
 	\deftranslation[to=khmer]{Examples}{\examplename}%
 	\AtEndDocument{\immediate\write\@auxout{\string\@writefile{nav}%
 		{\noexpand\headcommand{\noexpand\def\noexpand%
-		\inserttotalframenumber{\localnumber{framenumber}}}}}}%
+		\inserttotalframenumber{\localnumber*{framenumber}}}}}}%
 }{}
 \endinput

--- a/tex/gloss-lao.ldf
+++ b/tex/gloss-lao.ldf
@@ -90,7 +90,7 @@ and may look very wrong.}
 \def\lao@globalnumbers{%
    \let\orig@arabic\@arabic%
    \let\@arabic\laonumber%
-   \renewcommand{\thefootnote}{\localnumber{footnote}}%
+   \renewcommand{\thefootnote}{\localnumber*{footnote}}%
 }
 \def\nolao@globalnumbers{%
    \let\@arabic\orig@arabic%

--- a/tex/gloss-russian.ldf
+++ b/tex/gloss-russian.ldf
@@ -7,7 +7,8 @@
   hyphenmins={2,2},
   frenchspacing=true,
   fontsetup,
-  localnumber=russiannumerals
+  localnumber=russiannumerals,
+  Localnumber=Russiannumerals
   %TODO localalph={russian@alph,russian@Alph}
 }
 
@@ -214,6 +215,7 @@
 }
 
 \newcommand{\russiannumerals}[2]{\russiannumber{#2}}
+\newcommand{\Russiannumerals}[2]{\Russiannumber{#2}}
 
 \def\russiannumber#1{%
   \ifcyrillic@numerals

--- a/tex/gloss-serbian.ldf
+++ b/tex/gloss-serbian.ldf
@@ -10,7 +10,8 @@
   hyphenmins={2,2},
   indentfirst=true,
   fontsetup=false,
-  localnumber=serbiannumerals
+  localnumber=serbiannumerals,
+  Localnumber=Serbiannumerals
   %TODO localalph
 }
 
@@ -127,6 +128,7 @@
 
 
 \newcommand{\serbiannumerals}[2]{\serbiannumber{#2}}
+\newcommand{\Serbiannumerals}[2]{\Serbiannumber{#2}}
 
 \def\serbiannumber#1{%
   \ifserbian@numerals

--- a/tex/gloss-syriac.ldf
+++ b/tex/gloss-syriac.ldf
@@ -165,7 +165,7 @@ and may look very wrong.}
 
 \def\syriac@globalnumbers{%
   \let\@arabic\syriacnumber%
-  \renewcommand\thefootnote{\localnumber{footnote}}%
+  \renewcommand\thefootnote{\localnumber*{footnote}}%
 }
 
 \def\nosyriac@globalnumbers{%

--- a/tex/gloss-thai.ldf
+++ b/tex/gloss-thai.ldf
@@ -123,7 +123,7 @@ and may look very wrong.}
 \def\thai@globalnumbers{%
    \let\orig@arabic\@arabic%
    \let\@arabic\thainumber%
-   \renewcommand{\thefootnote}{\localnumber{footnote}}%
+   \renewcommand{\thefootnote}{\localnumber*{footnote}}%
 }
 \def\nothai@globalnumbers{%
    \let\@arabic\orig@arabic%

--- a/tex/gloss-tibetan.ldf
+++ b/tex/gloss-tibetan.ldf
@@ -144,7 +144,7 @@
 \def\tibetan@globalnumbers{%
    \let\xpg@orig@arabic\@arabic%
    \let\@arabic\tibetannumber%
-   \renewcommand{\thefootnote}{\localnumber{footnote}}%
+   \renewcommand{\thefootnote}{\localnumber*{footnote}}%
 }
 
 \def\notibetan@globalnumbers{%

--- a/tex/gloss-urdu.ldf
+++ b/tex/gloss-urdu.ldf
@@ -126,7 +126,7 @@ and may look very wrong.}
 \def\urdu@globalnumbers{%
   \let\@arabic\urdunumber%
   % For some reason \thefootnote needs to be set separately:
-  \renewcommand\thefootnote{\localnumber{footnote}}%
+  \renewcommand\thefootnote{\localnumber*{footnote}}%
 }
 
 \def\nourdu@globalnumbers{

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -899,7 +899,11 @@
     \str_if_eq:eeTF{\prop_item:Nn{\polyglossia@langsetup}{#2/direction}}{RL}{%
       \str_case_e:nnF{\c_sys_engine_str}{%
          {luatex}{\setRTLmain}
-         {xetex}{\@RTLmaintrue}
+         {xetex}{%
+            \@RTLmaintrue%
+            \autofootnoterule%
+            \RTLdblcol%
+         }
       }{}%
     }{}%
     \cs_gset_nopar:Nn \polyglossia@AtBeginDocument@selectlanguage: {

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -424,7 +424,14 @@
             \prop_gput:Nnn{\polyglossia@langsetup}{#1/localnumber}{##1}
          },
     #1 / localnumber.value_required:n = true,
-    #1 / localnumber.initial:n = {polyglossia@C@localnumber}
+    #1 / localnumber.initial:n = {polyglossia@C@localnumber},
+    % uppercased
+    #1 / Localnumber
+         . code:n =  {
+            \prop_gput:Nnn{\polyglossia@langsetup}{#1/Localnumber}{##1}
+         },
+    #1 / Localnumber.value_required:n = true,
+    #1 / Localnumber.initial:n = {polyglossia@C@localnumber}
   }
 }
 
@@ -442,6 +449,10 @@
   \use:c {\prop_item:Nn \polyglossia@langsetup  {#3/localnumber}} {#1} {#2}
 }
 
+\cs_new:Nn \polyglossia_Localnumber_mainlang:nnnn {
+  \use:c {\prop_item:Nn \polyglossia@langsetup  {#3/Localnumber}} {#1} {#2}
+}
+
 % print using local language
 % #2 is the numeral to print
 % #3 is the mainlanguage (should be expanded)
@@ -451,6 +462,10 @@
   \use:c {\prop_item:Nn \polyglossia@langsetup  {#4/localnumber}} {#1} {#2}
 }
 
+\cs_new:Nn \polyglossia_Localnumber_locallang:nnnn {
+  \use:c {\prop_item:Nn \polyglossia@langsetup  {#4/Localnumber}} {#1} {#2}
+}
+
 % this function try to resolve some simple parameter about lang
 % call #2 then branching if found
 % call parameter #3 if not found
@@ -458,6 +473,13 @@
 \cs_new:Npn \polyglossia_localnumber_callshortcutorlong:nF #1#2 {
   \str_case:nnF{#1}{
     {lang=local}{\polyglossia_localnumber_locallang:nnnn}
+  }
+  {#2}
+}
+
+\cs_new:Npn \polyglossia_Localnumber_callshortcutorlong:nF #1#2 {
+  \str_case:nnF{#1}{
+    {lang=local}{\polyglossia_Localnumber_locallang:nnnn}
   }
   {#2}
 }
@@ -473,9 +495,24 @@
   }
 }
 
+\cs_new:Npn \polyglossia_iii_map_csv_field_split_kv_iii_Localnumber:w  #1 = #2 \q_stop {
+  \str_case:nnF{#2}{
+    {local}  {\clist_map_break:n{\use_i:nn \polyglossia_Localnumber_locallang:nnnn }}
+    {default}{\clist_map_break:n{\use_i:nn \polyglossia_Localnumber_locallang:nnnn }}
+    {*}      {\clist_map_break:n{\use_i:nn\polyglossia_Localnumber_mainlang:nnnn   }}
+    {main}   {\clist_map_break:n{\use_i:nn\polyglossia_Localnumber_mainlang:nnnn   }}
+  }{
+    \clist_map_break:n{ \use_i_ii:nnn \polyglossia_Localnumber_langlang:nnnnn {{#2}} }
+  }
+}
+
 % call the language
 \cs_new:Nn \polyglossia_localnumber_langlang:nnnnn {
   \use:c {\prop_item:Nn \polyglossia@langsetup  {#1/localnumber}} {#2} {#3}
+}
+
+\cs_new:Nn \polyglossia_Localnumber_langlang:nnnnn {
+  \use:c {\prop_item:Nn \polyglossia@langsetup  {#1/Localnumber}} {#2} {#3}
 }
 
 
@@ -506,6 +543,32 @@
   }
 }
 
+\cs_new:Npn \polyglossia_iii_map_csv_field_split_kv_ii_Localnumber:w  #1 #2 = #3 \q_stop {
+  \quark_if_no_value:NTF {#3}
+  {
+    \clist_map_break:n{\use_i:nn \polyglossia_Localnumber_locallang:nnnn}
+  }
+  {
+    \polyglossia_iii_map_csv_field_split_kv_iii_Localnumber:w #1 \q_stop
+  }
+}
+
+\cs_new:Npn \polyglossia_iii_map_csv_field_split_kv_i_Localnumber:nw #1 #2 = #3 \q_stop {
+  % parse only lang tag
+  \tl_trim_spaces_apply:nN {#2} \str_if_eq:nnT {lang}
+  {
+    % if empty value
+    \quark_if_nil:nTF{#3}
+    {
+      \clist_map_break:n{\use_i:nn \polyglossia_Localnumber_locallang:nnnn}
+    }
+    {
+      % here we know what we have an equal sign
+      \polyglossia_iii_map_csv_field_split_kv_ii_Localnumber:w {#1} #1 \q_no_value \q_stop
+    }
+  }
+}
+
 
 % map function 
 \cs_new:Nn \polyglossia_iii_map_csv_localnumber:n {
@@ -516,6 +579,13 @@
   }
 }
 
+\cs_new:Nn \polyglossia_iii_map_csv_Localnumber:n {
+  % fast case is do nothing is empty 
+  \tl_if_empty:nF{#1}
+  {
+    \polyglossia_iii_map_csv_field_split_kv_i_Localnumber:nw {#1} #1 = \q_nil \q_stop
+  }
+}
 
 % treat option is empty and option is lang=local
 % #2 number
@@ -547,6 +617,30 @@
   }
 }
 
+\cs_new:Nn \polyglossia_iii_Localnumber:nnnn {
+  \tl_if_blank:nTF{#1}
+  {
+    \polyglossia_Localnumber_mainlang:nnnn
+  }
+  {
+    \str_if_eq:nnTF{#1}{lang=local}
+    {
+      \polyglossia_Localnumber_locallang:nnnn
+    }
+    {
+      % use postscript like trick push to stack {#1} {#2} {#3} {#4}
+      \polyglossia_Localnumber_callshortcutorlong:nF {#1}
+      {
+        % same trick here if found we emit  \use_i:nn
+        % thus discarding the default choice that is not lang specified thus local
+        \clist_map_function:nN {#1} {\polyglossia_iii_map_csv_Localnumber:n}
+        \polyglossia_Localnumber_locallang:nnnn
+      }
+    }
+    {#1} {#2} {#3} {#4}
+  }
+}
+
 % internal helper useful for oeee and onnn
 % #1 number
 % #2 mainlanguage
@@ -560,6 +654,13 @@
   eeen, eeeo
 }
 
+\cs_new:Nn \polyglossia_ii_Localnumber:nnnn {
+  \tl_trim_spaces_apply:nN {#4} \polyglossia_iii_Localnumber:nnnn {#1}{#2}{#3}
+}
+\cs_generate_variant:Nn \polyglossia_ii_Localnumber:nnnn {
+  eeen, eeeo
+}
+
 % convert the counter to value
 % #1 counter
 % #2 mainlanguage
@@ -570,24 +671,42 @@
   \polyglossia_ii_localnumber:eeeo {\int_value:w #1} {#2} {#3} {#4}
 }
 
-% print number usage Localnumber[option]{numeral}
-% \Localnumber[]{numeral} use main language
-% \localnumber{numeral} use local language
-\NewExpandableDocumentCommand{\Localnumber}{om}
+\cs_new:Nn \polyglossia_i_Localnumber:nnnn
 {
-  \polyglossia_ii_localnumber:eeeo {\int_eval:n{#2}}
-      {\mainlanguagename} {\languagename} {\IfNoValueTF {#1}{lang=local}{#1}}
+  \polyglossia_ii_Localnumber:eeeo {\int_value:w #1} {#2} {#3} {#4}
 }
 
-% print number usage Localnumber[option]{counter}
+% print number usage \localnumber[option]{numeral}
+% or \localnumber*[option]{counter}
 % \Localnumber[]{numeral} use main language
 % \localnumber{numeral} use local language
-\NewExpandableDocumentCommand{\localnumber}{om}
+\NewExpandableDocumentCommand{\localnumber}{som}
 {
-  \exp_args:Nc \polyglossia_i_localnumber:nnnn {c@#2}
-      {\mainlanguagename} {\languagename} {\IfNoValueTF {#1}{lang=local}{#1}}
+  \IfBooleanTF{#1}%
+    {% starred: take counter
+      \exp_args:Nc \polyglossia_i_localnumber:nnnn {c@#3}
+         {\mainlanguagename} {\languagename} {\IfNoValueTF {#2}{lang=local}{#2}}
+    }{% unstarred: take number
+      \polyglossia_ii_localnumber:eeeo {\int_eval:n{#3}}
+         {\mainlanguagename} {\languagename} {\IfNoValueTF {#2}{lang=local}{#2}}
+    }
 }
 
+% print number usage \Localnumber[option]{numeral}
+% or \Localnumber*[option]{counter}
+% \Localnumber[]{numeral} use main language
+% \localnumber{numeral} use local language
+\NewExpandableDocumentCommand{\Localnumber}{som}
+{
+  \IfBooleanTF{#1}%
+    {% starred: take counter
+      \exp_args:Nc \polyglossia_i_Localnumber:nnnn {c@#3}
+         {\mainlanguagename} {\languagename} {\IfNoValueTF {#2}{lang=local}{#2}}
+    }{% unstarred: take number
+      \polyglossia_ii_Localnumber:eeeo {\int_eval:n{#3}}
+         {\mainlanguagename} {\languagename} {\IfNoValueTF {#2}{lang=local}{#2}}
+    }
+}
 
 \cs_new_nopar:Nn{\polyglossia@lang@frenchspacing:n}{
   \prop_get:NnNTF \polyglossia@langsetup {#1/frenchspacing} \l_tmpa_tl

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -899,11 +899,7 @@
     \str_if_eq:eeTF{\prop_item:Nn{\polyglossia@langsetup}{#2/direction}}{RL}{%
       \str_case_e:nnF{\c_sys_engine_str}{%
          {luatex}{\setRTLmain}
-         {xetex}{%
-            \@RTLmaintrue%
-            \autofootnoterule%
-            \RTLdblcol%
-         }
+         {xetex}{\@RTLmaintrue}
       }{}%
     }{}%
     \cs_gset_nopar:Nn \polyglossia@AtBeginDocument@selectlanguage: {


### PR DESCRIPTION
This moves the counter macros to starred variants `\localnumber*` and `\Localnumber*`

The proposed renaming to `\localnumeral` is a different task.