### PR TITLE
Rewrite \set@language@luatex

### DIFF
--- a/tex/gloss-english.ldf
+++ b/tex/gloss-english.ldf
@@ -110,12 +110,7 @@
 \fi
 
 \def\english@language{%
-   \ifxetex
-      \language=\csname l@\english@variant\endcsname
-   \fi
-   \ifluatex
-      \xpg@set@language@luatex@iv{\english@variant}
-   \fi
+   \xpg@set@hyphenation@patterns{\english@variant}
 }%
 
 \def\captionsenglish{%

--- a/tex/gloss-french.ldf
+++ b/tex/gloss-french.ldf
@@ -35,12 +35,7 @@
 
 
 \def\french@language{%
-   \ifxetex
-      \language=\csname l@\french@variant\endcsname
-   \fi
-   \ifluatex
-      \xpg@set@language@luatex@iv{\french@variant}
-   \fi
+   \xpg@set@hyphenation@patterns{\french@variant}
 }%
 
 \ifluatex

--- a/tex/gloss-german.ldf
+++ b/tex/gloss-german.ldf
@@ -191,43 +191,28 @@
   \if@german@fraktur\date@german@fraktur\else\date@german\fi
 }
 
-\def\german@language{\ifxetex\language=%
-  \csname l@%
-    \if@swiss@locale
-       \if@german@oldspelling
-           swissgerman%
-       \else
-            ngerman%
-            \ifgerman@latesthyphen
-                -x-latest
-            \fi
-        \fi
-    \else% (german, austrian)
-      \if@german@oldspelling\else n\fi german\ifgerman@latesthyphen -x-latest\fi
-    \fi
-  \endcsname\else\ifluatex
-  % LuaTeX
+\def\german@language{%
   \ifgerman@latesthyphen
     \if@german@oldspelling
         \if@swiss@locale
-            \xpg@set@language@luatex@iv{swissgerman}%
+            \xpg@set@hyphenation@patterns{swissgerman}%
         \else
-            \xpg@set@language@luatex@iv{german-x-latest}%
+            \xpg@set@hyphenation@patterns{german-x-latest}%
         \fi
     \else
-        \xpg@set@language@luatex@iv{ngerman-x-latest}%
+        \xpg@set@hyphenation@patterns{ngerman-x-latest}%
     \fi
   \else% (latesthyphen=false)
     \if@german@oldspelling
         \if@swiss@locale
-            \xpg@set@language@luatex@iv{swissgerman}%
+            \xpg@set@hyphenation@patterns{swissgerman}%
         \else
-            \xpg@set@language@luatex@iv{german}%
+            \xpg@set@hyphenation@patterns{german}%
         \fi
     \else
-        \xpg@set@language@luatex@iv{ngerman}%
+        \xpg@set@hyphenation@patterns{ngerman}%
     \fi
-  \fi\fi\fi
+  \fi
 }
 
 \def\noextras@german{%

--- a/tex/gloss-greek.ldf
+++ b/tex/gloss-greek.ldf
@@ -68,12 +68,7 @@
   \fi}
 
 \def\greek@language{%
-  \ifxetex% XeTeX
-     \language=\csname l@\greek@variant\endcsname
-  \fi%
-  \ifluatex% LuaTeX
-     \xpg@set@language@luatex@iv{\greek@variant}
-  \fi
+  \xpg@set@hyphenation@patterns{\greek@variant}
 }
 
 

--- a/tex/gloss-portuguese.ldf
+++ b/tex/gloss-portuguese.ldf
@@ -24,12 +24,7 @@
 
 
 \def\portuguese@language{%
-   \ifxetex
-      \language=\csname l@\portuguese@variant\endcsname
-   \fi
-   \ifluatex
-      \xpg@set@language@luatex@iv{\portuguese@variant}
-   \fi
+   \xpg@set@hyphenation@patterns{\portuguese@variant}
 }%
 
 \def\captionsportuguese@portuges{%

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -1274,13 +1274,11 @@
       {luatex}{%
         \polyglossia@check@ifdefined:NF{#1}{%
             \expandafter\chardef\csname l@#1\endcsname=\directlua{tex.sprint(polyglossia.newloader('#1'))}%
-            \language=\csname l@#1\endcsname%
         }%
+        \language=\csname l@#1\endcsname%
       }%
       {xetex}{%
-        \polyglossia@check@ifdefined:NF{#1}{%
-           \language=\csname l@#1\endcsname%
-        }%
+        \language=\csname l@#1\endcsname%
       }%
     }%
     {

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -1238,38 +1238,49 @@
     \polyglossia@check@ifdefined:NTF{#1}{#2}{#3}
 }%
 
+% Set \bbl@hyphendata@\the\language, which is (lua)babel's
+% hyphenation pattern hook
+% FIXME Clarifiy why/when this is needed.
 \newcommand*\xpg@set@bbl@hyphendata[1]{%
-    % here we use lu@texhyphen@loaded@\the\language, the same as in babel
-    \ifcsdef{bbl@hyphendata@#1}{}{%
-        \global\@namedef{bbl@hyphendata@\the\language}{}%
-    }
+    \ifluatex%
+        \ifcsdef{bbl@hyphendata@#1}{}{%
+            \global\@namedef{bbl@hyphendata@\the\language}{}%
+        }%
+    \fi% 
 }
 
+% Set hyphenation patterns for a given language. This does the right
+% thing both for XeTeX and LuaTeX
 \newcommand\xpg@set@hyphenation@patterns[1]{%
-    \ifluatex
-        \polyglossia@check@ifdefined:NF{#1}{
+    \str_case_e:nnF{\c_sys_engine_str}{%
+      {luatex}{%
+        \polyglossia@check@ifdefined:NF{#1}{%
             \expandafter\chardef\csname l@#1\endcsname=\directlua{tex.sprint(polyglossia.newloader('#1'))}%
-        }
-    \fi
-    \polyglossia@check@ifdefined:NF{#1}{
-        \language=\csname l@#1\endcsname
-    }
+            \language=\csname l@#1\endcsname%
+        }%
+      }%
+      {xetex}{%
+        \polyglossia@check@ifdefined:NF{#1}{%
+           \language=\csname l@#1\endcsname%
+        }%
+      }%
+    }%
+    {
+      \xpg@warning{You’re running a TeX engine that is not LuaTeX or XeTeX.\MessageBreak
+        That is almost guaranteed to cause problems.}%
+    }%
 }
 
 % FIXME: Remove after gloss-latin (last user) has been rewritten)
 \newcommand\xpg@set@language@luatex@ii[1]{%
-   \ifluatex %
      \xpg@set@bbl@hyphendata{\expandafter\the\csname l@#1\endcsname}
-   \fi % 
 }
 
 
 \def\@select@language#1{
    % hook for compatibility with biblatex
    \select@language{#1}
-   \ifluatex %
-      \xpg@set@bbl@hyphendata{\the\language}
-   \fi %
+   \xpg@set@bbl@hyphendata{\the\language}
    \xpg@initial@setup%
    \select@@language{#1}%
    \csuse{captions#1}%

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -248,7 +248,7 @@
                  \cs_if_eq:cNF{l@#1}{\l@nohyphenation}{\global\booltrue{havehyphen}}{%
                    % if false define language to hyphenation and load
                    \cs_gset_eq:cc{l@#1}{l@##1}
-                   \xpg@set@language@luatex@iv{##1}
+                   \xpg@set@hyphenation@patterns{##1}
                    \global\booltrue{havehyphen}
                  }
               }
@@ -272,12 +272,9 @@
     \ifbool{xpg@hyphenation@disabled}{%
       \xdef\xpg@lastlanguage{\the\csname l@#1\endcsname}%
     }{%
-      \ifluatex%
-        \cs_if_eq:cNF{l@#1}{\l@nohyphenation}{%
-          \xpg@set@language@luatex@iv{#1}%
-        }%
-      \fi%
-      \language=\csname l@#1\endcsname%
+      \cs_if_eq:cNF{l@#1}{\l@nohyphenation}{%
+          \xpg@set@hyphenation@patterns{#1}%
+      }%
     }%
   }%
   % setup hypenmins
@@ -680,7 +677,7 @@
   \ifbool{xpg@hyphenation@disabled}{}{%
     \booltrue{xpg@hyphenation@disabled}%
     \xdef\xpg@lastlanguage{\the\language}%
-    % We do not call \xpg@set@language@luatex@iv here to avoid a warning message.
+    % We do not call \xpg@set@hyphenation@patterns here to avoid a warning message.
     % "nohyphenation" is not listed in language.dat.lua.
     \language=\l@nohyphenation%
   }%
@@ -1228,13 +1225,6 @@
    \fi
 }
 
-\def\xpg@set@language@luatex@iii#1#2{%
-    % here we use lu@texhyphen@loaded@\the\language, the same as in babel
-    \ifcsdef{bbl@hyphendata@#2}{}{%
-        \global\@namedef{bbl@hyphendata@\the\language}{}%
-    }
-}
-
 \prg_set_conditional:Npnn \polyglossia@check@ifdefined:N #1 { p , T , F , TF }{
   \cs_if_exist:cTF{l@#1}{
     \cs_if_eq:cNTF{l@#1}{\l@nohyphenation}{\prg_return_false:}{\prg_return_true:}
@@ -1244,33 +1234,41 @@
 }
 
 \newcommand\xpg@ifdefined[3]{%
-    \ifluatex
-        \xpg@set@language@luatex@iv{#1}%
-    \fi
+    \xpg@set@hyphenation@patterns{#1}%
     \polyglossia@check@ifdefined:NTF{#1}{#2}{#3}
 }%
 
-\newcommand\xpg@set@language@luatex@iv[1]{%
+\newcommand*\xpg@set@bbl@hyphendata[1]{%
+    % here we use lu@texhyphen@loaded@\the\language, the same as in babel
+    \ifcsdef{bbl@hyphendata@#1}{}{%
+        \global\@namedef{bbl@hyphendata@\the\language}{}%
+    }
+}
+
+\newcommand\xpg@set@hyphenation@patterns[1]{%
     \ifluatex
         \polyglossia@check@ifdefined:NF{#1}{
             \expandafter\chardef\csname l@#1\endcsname=\directlua{tex.sprint(polyglossia.newloader('#1'))}%
         }
-        \language=\csname l@#1\endcsname
     \fi
+    \polyglossia@check@ifdefined:NF{#1}{
+        \language=\csname l@#1\endcsname
+    }
 }
 
+% FIXME: Remove after gloss-latin (last user) has been rewritten)
 \newcommand\xpg@set@language@luatex@ii[1]{%
    \ifluatex %
-     \xpg@set@language@luatex@iii{#1}{\expandafter\the\csname l@#1\endcsname}
+     \xpg@set@bbl@hyphendata{\expandafter\the\csname l@#1\endcsname}
    \fi % 
 }
 
 
 \def\@select@language#1{
-  % hook for compatibility with biblatex
-  \select@language{#1}
-  \ifluatex %
-      \xpg@set@language@luatex@iii{#1}{\the\language}
+   % hook for compatibility with biblatex
+   \select@language{#1}
+   \ifluatex %
+      \xpg@set@bbl@hyphendata{\the\language}
    \fi %
    \xpg@initial@setup%
    \select@@language{#1}%

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -272,7 +272,9 @@
     \ifbool{xpg@hyphenation@disabled}{%
       \xdef\xpg@lastlanguage{\the\csname l@#1\endcsname}%
     }{%
-      \cs_if_eq:cNF{l@#1}{\l@nohyphenation}{%
+      \cs_if_eq:cNTF{l@#1}{\l@nohyphenation}{%
+          \language=\l@nohyphenation%
+      }{%
           \xpg@set@hyphenation@patterns{#1}%
       }%
     }%


### PR DESCRIPTION
See reutenauer/polyglossia#283

This marks `\set@language@luatex@ii` obsolete (only used in gloss-latin, currently under rewrite by @wehro), renames `\set@language@luatex@iii` to `\xpg@set@bbl@hyphendata` and `\set@language@luatex@iv` to `\xpg@set@hyphenation@patterns`. The latter function now can be called also from XeTeX. This simplifies the code in some gloss files.

Note that I don't propose to merge this before the release, as some further testing would be good.