### PR TITLE
Making polyglossia-frpt.lua generic.

### DIFF
--- a/doc/Changelog
+++ b/doc/Changelog
@@ -3,6 +3,7 @@
 New features:
   * Add new macros \localnumeral, \localnumeral*, \Localnumeral and
     \Localnumeral* that convert Arabic digitals to the local number scheme.
+  * Add support for (Sorani) Kurdish (#277).
   * Implement proper Cyrillic (alphanumeric) numbering (#285).
   * gloss-serbian: add numerals=cyrillic option. Add \asbuk and \Asbuk (#285).
   * Implement basic support for (French) canadien and (English) canadian (#22)

--- a/doc/Changelog
+++ b/doc/Changelog
@@ -5,6 +5,9 @@ New features:
     \Localnumeral* that convert Arabic digitals to the local number scheme.
   * Add support for (Sorani) Kurdish (#277).
   * Implement proper Cyrillic (alphanumeric) numbering (#285).
+  * Add new language portuguese with variants portuguese and brazilian.
+    This deprecates brazil and portuges (which are still supported for
+    backwards compatibility).
   * gloss-serbian: add numerals=cyrillic option. Add \asbuk and \Asbuk (#285).
   * Implement basic support for (French) canadien and (English) canadian (#22)
   * Improve support for Armenian (#79): Add captions, Eastern month names

--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -178,22 +178,22 @@ that are explained in section \ref{specific} below.
 % Edited by hand -- AR 2019-04-04
 \begin{tabular}{lllll}
 \hline
-albanian       & danish         & interlingua    & nko            & \TX{slovenian}\\
-amharic        & divehi         & irish          & norsk          & spanish       \\
-\TX{arabic}    & \TX{dutch}     & \TX{italian}   & nynorsk        & swedish       \\
-\TX{armenian}  & \TX{english}   & japanese       & occitan        & \TX{syriac}   \\
-asturian       & \TX{esperanto} & kannada        & piedmontese    & tamil         \\
-bahasai        & estonian       & khmer          & polish         & telugu        \\
-bahasam        & \TX{farsi}     & \TX{korean}    & portuges       & \TX{thai}     \\
-basque         & \TX{finnish}   & \TX{lao}       & romanian       & \TX{tibetan}  \\
-\TX{bengali}   & \TX{french}    & \TX{latin}     & romansh        & turkish       \\
-brazil[ian]    & friulan        & latvian        & \TX{russian}   & turkmen       \\
-breton         & galician       & lithuanian     & samin          & \TX{ukrainian}\\
-bulgarian      & \TX{german}    & \TX{lsorbian}  & \TX{sanskrit}  & urdu          \\
-\TX{catalan}   & \TX{greek}     & \TX{magyar}    & scottish       & \TX{usorbian} \\
-coptic         & \TX{hebrew}    & macedonian     & \TX{serbian}   & vietnamese    \\
-croatian       & \TX{hindi}     & malayalam      & slovak         & \TX{welsh}    \\
-czech          & icelandic      & marathi         \\
+albanian       & danish         & interlingua    & marathi        & \TX{slovenian}\\
+amharic        & divehi         & irish          & nko            & spanish       \\
+\TX{arabic}    & \TX{dutch}     & \TX{italian}   & norsk          & swedish       \\
+\TX{armenian}  & \TX{english}   & japanese       & nynorsk        & \TX{syriac}   \\
+asturian       & \TX{esperanto} & kannada        & occitan        & tamil         \\
+bahasai        & estonian       & khmer          & piedmontese    & telugu        \\
+bahasam        & \TX{farsi}     & \TX{korean}    & polish         & \TX{thai}     \\
+basque         & \TX{finnish}   & \TX{kurdish}   & portuges       & \TX{tibetan}  \\
+\TX{bengali}   & \TX{french}    & \TX{lao}       & romanian       & turkish       \\
+brazil[ian]    & friulan        & \TX{latin}     & romansh        & turkmen       \\
+breton         & galician       & latvian        & \TX{russian}   & \TX{ukrainian}\\
+bulgarian      & \TX{german}    & lithuanian     & samin          & urdu          \\
+\TX{catalan}   & \TX{greek}     & \TX{lsorbian}  & \TX{sanskrit}  & \TX{usorbian} \\
+coptic         & \TX{hebrew}    & \TX{magyar}    & scottish       & vietnamese    \\
+croatian       & \TX{hindi}     & macedonian     & \TX{serbian}   & \TX{welsh}    \\
+czech          & icelandic      & malayalam      & slovak\\
 \hline
 \end{tabular}
 \caption{Languages currently supported in \pkg{polyglossia}}
@@ -588,6 +588,23 @@ The default value of each option is given in italic.
     `modern' for text with interword spaces.
   \item \TB{captions} = \textit{hangul} or hanja
   \end{itemize}
+
+\subsection{kurdish}\label{kurdish}
+Currently\new{v1.45} support for Kurdish is limited to Sorani Kurdish (support for Kurmanji Kurdish is planned).
+
+\noindent\textbf{Options}:
+\begin{itemize}
+	\item \TB{numerals} = western or \textit{eastern}
+	\item \TB{abjadjimnotail} = \textit{false} or true.
+	Set this to true if you want the \textit{abjad} form of the number three to be \textarabic{ج‍} – as in the manuscript tradition – instead of the modern usage \textarabic{ج}.
+	\item \TB{locale} (not yet implemented)
+	\item \TB{calendar} (not yet implemented)
+\end{itemize}
+\textbf{Commands}:
+\begin{itemize}
+	\item \Cmd\abjad (see section \ref{abjad})
+	\item \Cmd\aemph (see section \ref{arabic}).
+\end{itemize}
 
 \subsection{lao}\label{lao}\new{v1.2.0}
 \textbf{Options}:

--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -178,16 +178,16 @@ that are explained in section \ref{specific} below.
 % Edited by hand -- AR 2019-04-04
 \begin{tabular}{lllll}
 \hline
-albanian       & danish         & interlingua    & marathi        & \TX{slovenian}\\
-amharic        & divehi         & irish          & nko            & spanish       \\
-\TX{arabic}    & \TX{dutch}     & \TX{italian}   & norsk          & swedish       \\
-\TX{armenian}  & \TX{english}   & japanese       & nynorsk        & \TX{syriac}   \\
-asturian       & \TX{esperanto} & kannada        & occitan        & tamil         \\
-bahasai        & estonian       & khmer          & piedmontese    & telugu        \\
-bahasam        & \TX{farsi}     & \TX{korean}    & polish         & \TX{thai}     \\
-basque         & \TX{finnish}   & \TX{kurdish}   & portuguese     & \TX{tibetan}  \\
-\TX{bengali}   & \TX{french}    & \TX{lao}       & romanian       & turkish       \\
-brazil[ian]    & friulan        & \TX{latin}     & romansh        & turkmen       \\
+               & danish         & interlingua    & marathi        & \TX{slovenian}\\
+albanian       & divehi         & irish          & nko            & spanish       \\
+amharic        & \TX{dutch}     & \TX{italian}   & norsk          & swedish       \\
+\TX{arabic}    & \TX{english}   & japanese       & nynorsk        & \TX{syriac}   \\
+\TX{armenian}  & \TX{esperanto} & kannada        & occitan        & tamil         \\
+asturian       & estonian       & khmer          & piedmontese    & telugu        \\
+bahasai        & \TX{farsi}     & \TX{korean}    & polish         & \TX{thai}     \\
+bahasam        & \TX{finnish}   & \TX{kurdish}   & \TX{portuguese}& \TX{tibetan}  \\
+basque         & \TX{french}    & \TX{lao}       & romanian       & turkish       \\
+\TX{bengali}   & friulan        & \TX{latin}     & romansh        & turkmen       \\
 breton         & galician       & latvian        & \TX{russian}   & \TX{ukrainian}\\
 bulgarian      & \TX{german}    & lithuanian     & samin          & urdu          \\
 \TX{catalan}   & \TX{greek}     & \TX{lsorbian}  & \TX{sanskrit}  & \TX{usorbian} \\
@@ -631,6 +631,11 @@ Currently\new{v1.45} support for Kurdish is limited to Sorani Kurdish (support f
 		(see the \pkg{babel} documentation).
 	\end{itemize}
 
+\subsection{portuguese}\label{portuguese}
+\textbf{Options}:
+\begin{itemize}
+	\item \TB{variant}\new{v1.45} = brazilian or \textit{portuguese}
+\end{itemize}
 
 \subsection{russian}\label{russian}
 \textbf{Options}:

--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -185,7 +185,7 @@ amharic        & divehi         & irish          & nko            & spanish     
 asturian       & \TX{esperanto} & kannada        & occitan        & tamil         \\
 bahasai        & estonian       & khmer          & piedmontese    & telugu        \\
 bahasam        & \TX{farsi}     & \TX{korean}    & polish         & \TX{thai}     \\
-basque         & \TX{finnish}   & \TX{kurdish}   & portuges       & \TX{tibetan}  \\
+basque         & \TX{finnish}   & \TX{kurdish}   & portuguese     & \TX{tibetan}  \\
 \TX{bengali}   & \TX{french}    & \TX{lao}       & romanian       & turkish       \\
 brazil[ian]    & friulan        & \TX{latin}     & romansh        & turkmen       \\
 breton         & galician       & latvian        & \TX{russian}   & \TX{ukrainian}\\

--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -764,10 +764,15 @@ For\new{1.45} the conversion of counters, the starred version \Cmd{\localnumeral
 For instance in an Arabic environment ¦\localnumeral*{page}¦ yields \textarabic{\localnumeral*{page}}.
 
 For scripts with alphanumeric numbering, the variants \Cmd{\Localnumeral} and \Cmd{\Localnumeral*} provide the uppercased 
-versions.
+versions.\medskip
 
-All\DescribeMacro{[lang=main]}\ these macros return the local numbering for the main language (rather than the locally selected language)
-if the optional argument ¦lang=main¦ is given, \eg ¦\localnumeral[lang=main]{4711}¦.
+\noindent All these macros provide the following options:
+
+\begin{itemize}
+	\item \TB{lang} =\DescribeMacro{[lang=]}\ \textit{local}, main, or <language>.\\
+	Output number in the local form of the currently active language for ¦local¦, the main language of the document for ¦main¦,
+    and any (loaded) language for ¦<language>¦ (\eg ¦\localnumeral[lang=arabic]{42}}¦).
+\end{itemize}
 
 \subsection{Non-Western decimal digits}\label{sec:decdigit}
 

--- a/tex/gloss-brazil.ldf
+++ b/tex/gloss-brazil.ldf
@@ -1,4 +1,16 @@
-\ProvidesFile{gloss-brazil.ldf}[polyglossia: module for portuguese]
+\ProvidesFile{gloss-brazil.ldf}[polyglossia: module for brazilian portuguese]
+
+% We only provide this gloss for backwards compatibility. The name
+% 'brazil' was selected in accordance with babel.
+% Since brazil is a variety of potuguese, we use 'portuguese' now.
+
+% FIXME: Once we support babel aliases (#112) this gloss can go.
+
+\xpg@warning{The language name 'brazil' is deprectated.\MessageBreak
+             Please use 'portuguese' with variant 'brazilian' instead.}
+
+\input{gloss-portuguese.ldf}
+
 \PolyglossiaSetup{brazil}{
   language=Brazilian Portuguese,
   langtag=PTG,
@@ -7,35 +19,7 @@
   fontsetup=true,
 }
 
-\def\captionsbrazil{%
-   \def\refname{Referências}%
-   \def\abstractname{Resumo}%
-   \def\bibname{Referências Bibliográficas}%
-   \def\prefacename{Prefácio}%
-   \def\chaptername{Capítulo}%
-   \def\appendixname{Apêndice}%
-   \def\contentsname{Sumário}%
-   \def\listfigurename{Lista de Figuras}%
-   \def\listtablename{Lista de Tabelas}%
-   \def\indexname{Índice Remissivo}%
-   \def\figurename{Figura}%
-   \def\tablename{Tabela}%
-   %\def\thepart{}%
-   \def\partname{Parte}%
-   \def\pagename{Página}%
-   \def\seename{veja}%
-   \def\alsoname{veja também}%
-   \def\enclname{Anexo}%
-   \def\ccname{Cópia para}%
-   \def\headtoname{Para}%
-   \def\proofname{Demonstração}%
-   \def\glossaryname{Glossário}%
-   }
-\def\datebrazil{%   
-   \def\today{\number\day\space de\space\ifcase\month\or
-      janeiro\or fevereiro\or março\or abril\or maio\or junho\or
-      julho\or agosto\or setembro\or outubro\or novembro\or dezembro%
-      \fi\space de\space\number\year}%
-      }
+\let\captionsportuges\captionsportuguese@brazil
+\let\dateportuges\dateportuguese@brazil
      
 \endinput

--- a/tex/gloss-croatian.ldf
+++ b/tex/gloss-croatian.ldf
@@ -1,8 +1,9 @@
 \ProvidesFile{gloss-croatian.ldf}[polyglossia: module for croatian]
 \PolyglossiaSetup{croatian}{
+  langtag=HRV,
   hyphennames={croatian},
   hyphenmins={2,2}, % aligned with https://ctan.org/pkg/hrhyph patterns and http://lebesgue.math.hr/~nenad/Diplomski/Maja_Ribaric_2011.pdf
-  langtag=HRV,
+  frenchspacing=true,
   indentfirst=false, % recommendation from Damir Bralić
   fontsetup=true
 }

--- a/tex/gloss-french.ldf
+++ b/tex/gloss-french.ldf
@@ -19,16 +19,16 @@
       % canadian:
       \gdef\french@variant{canadien}%
       \xpg@ifdefined{canadien}{}%
-	    {\xpg@warning{No hyphenation patterns were loaded for "French (Canada)"\MessageBreak
-	      I will use the standard patterns for French instead}%
-	    \adddialect\l@canadien\l@french\relax}%
+      {\xpg@warning{No hyphenation patterns were loaded for "French (Canada)"\MessageBreak
+        I will use the standard patterns for French instead}%
+      \adddialect\l@canadien\l@french\relax}%
    \or
       % acadian:
       \gdef\french@variant{acadian}%
       \xpg@ifdefined{acadian}{}%
-	    {\xpg@warning{No hyphenation patterns were loaded for "French (Canada)"\MessageBreak
-	      I will use the standard patterns for French instead}%
-	    \adddialect\l@acadian\l@french\relax}%
+      {\xpg@warning{No hyphenation patterns were loaded for "French (Canada)"\MessageBreak
+        I will use the standard patterns for French instead}%
+      \adddialect\l@acadian\l@french\relax}%
    \fi
    \xpg@info{Option: French, variant=\val}%
 }{\xpg@warning{Unknown French variant `#1'}}
@@ -44,8 +44,8 @@
 }%
 
 \ifluatex
-  \newluatexattribute\xpg@frpt %
-  \directlua{polyglossia.load_frpt()}%
+  \newluatexattribute\xpg@punct %
+  \directlua{require('polyglossia-french')}%
 \else
   \newXeTeXintercharclass\french@openbrackets % ( ] {
   \newXeTeXintercharclass\french@closebrackets % ( ] {
@@ -122,8 +122,8 @@
 \def\french@punctuation{%
     \lccode"2019="2019
     \ifluatex
-      \xpg@frpt=1\relax %
-      \directlua{polyglossia.activate_frpt()}%
+      \xpg@punct=1\relax %
+      \directlua{polyglossia.activate_french_punct()}%
     \else
       \XeTeXinterchartokenstate=1
       \XeTeXcharclass `\! \french@punctthin
@@ -169,14 +169,8 @@
 \def\nofrench@punctuation{%
     \lccode"2019=\z@
     \ifluatex
-      \xpg@frpt=0\relax %
-      % Though it would make compilation slightly faster, it is not possible to
-      % safely uncomment the following line. Imagine the following case: you start
-      % a paragraph by some french text, then, in the same paragraph, you change
-      % the language to something else, and thus call the following line. This means
-      % that, at then end of the paragraph, the function won't be in the callback,
-      % so the beginning of the paragraph won't be processed by it.
-      %\directlua{polyglossia.desactivate_frpt()}
+      \xpg@punct=0\relax %
+      \directlua{polyglossia.deactivate_french_punct()}%
     \else
       \XeTeXcharclass `\! \z@
       \XeTeXcharclass `\? \z@

--- a/tex/gloss-kurdish.ldf
+++ b/tex/gloss-kurdish.ldf
@@ -1,12 +1,6 @@
 % Created on September 1, 2019
 % Sina Ahmadi (https://sinaahmadi.github.io/)
 \ProvidesFile{gloss-kurdish.ldf}[polyglossia: module for Kurdish]
-\ifluatex
-  \xpg@warning{Kurdish is not supported with LuaTeX.\MessageBreak
-I will proceed with the compilation, but\MessageBreak
-the output is not guaranteed to be correct\MessageBreak
-and may look very wrong.}
-\fi
 \RequireBidi
 \RequirePackage{arabicnumbers}
 \RequirePackage{farsical}
@@ -17,7 +11,8 @@ and may look very wrong.}
   scripttag=arab,
   langtag=KUR,
   hyphennames={nohyphenation},
-  fontsetup=true
+  fontsetup=true,
+  localnumeral=kurdishnumerals
 }
 
 \newif\if@western@numerals
@@ -26,7 +21,8 @@ and may look very wrong.}
   \def\@tmpa{#1}%
   \ifx\@tmpa\tmp@western\@western@numeralstrue\else%
     \@western@numeralsfalse%
-  \fi}
+  \fi%
+}
 
 %this is needed for \abjad in arabicnumbers.sty
 \def\tmp@true{true}
@@ -35,7 +31,8 @@ and may look very wrong.}
   \ifx\@tmpa\tmp@true\abjad@jim@notailtrue%
   \else
     \abjad@jim@notailfalse
-  \fi}
+  \fi%
+}
 
 % NOT YET USED
 \define@key{kurdish}{locale}[default]{%
@@ -51,37 +48,43 @@ and may look very wrong.}
   \or کانونی دووەم\or شوبات\or ئازار\or نیسان\or ئایار\or حوزه‌یران\or ته‌ممووز\or ئاب\or ئه‌یلوول\or تشرینی یه‌كه‌م\or تشرینی دووهه‌م\or كانوونی یه‌كه‌م\fi}
 
 %\Hijritoday is now locale-aware and will format the date with this macro:
-\DefineFormatHijriDate{kurdish}{\@ensure@RTL{%
-\farsinumber{\value{Hijriday}}\space\HijriMonthArabic{\value{Hijrimonth}}\space\farsinumber{\value{Hijriyear}}}}
+\DefineFormatHijriDate{kurdish}{%
+  \@ensure@RTL{%
+    \kurdishnumber{\value{Hijriday}}\space\HijriMonthArabic{\value{Hijrimonth}}\space\kurdishnumber{\value{Hijriyear}}%
+  }%
+}
 
 \def\captionskurdish{%
-\def\prefacename{\@ensure@RTL{پێشه‌كی}}%
-\def\refname{\@ensure@RTL{سه‌رچاوه‌کان}}%
-\def\abstractname{\@ensure@RTL{پوخته‌}}%
-\def\bibname{\@ensure@RTL{کتێبنامه‌}}%
-\def\chaptername{\@ensure@RTL{به‌ندی}}%
-\def\appendixname{\@ensure@RTL{پاشکۆ}}%
-\def\contentsname{\@ensure@RTL{نێوه‌ڕۆک}}%
-\def\listfigurename{\@ensure@RTL{لیستی وێنه‌کان}}%
-\def\listtablename{\@ensure@RTL{لیستی خشته‌کان}}%
-\def\indexname{\@ensure@RTL{پێنوێن}}%
-\def\figurename{\@ensure@RTL{وێنه‌}}%
-\def\tablename{\@ensure@RTL{خشتە}}%
-\def\partname{\@ensure@RTL{به‌شی}}%
-\def\enclname{\@ensure@RTL{هاوپێچ}}%
-\def\ccname{\@ensure@RTL{روونووس}}%
-\def\headtoname{\@ensure@RTL{بۆ}}%
-\def\pagename{\@ensure@RTL{لاپه‌ڕه‌}}%
-\def\seename{\@ensure@RTL{چاو لێکه‌ن}}%
-\def\alsoname{\@ensure@RTL{هه‌روه‌ها چاو لێکه‌ن}}%
-\def\proofname{\@ensure@RTL{سەلماندن}}%
-\def\glossaryname{\@ensure@RTL{فه‌رهه‌نگۆک}}%
-}
-\def\datekurdish{%
-   \def\today{\@ensure@RTL{\farsinumber\day{ی}\space\kurdishmonth{\month}{ی}\space\farsinumber\year}}%
+  \def\prefacename{\@ensure@RTL{پێشه‌كی}}%
+  \def\refname{\@ensure@RTL{سه‌رچاوه‌کان}}%
+  \def\abstractname{\@ensure@RTL{پوخته‌}}%
+  \def\bibname{\@ensure@RTL{کتێبنامه‌}}%
+  \def\chaptername{\@ensure@RTL{به‌ندی}}%
+  \def\appendixname{\@ensure@RTL{پاشکۆ}}%
+  \def\contentsname{\@ensure@RTL{نێوه‌ڕۆک}}%
+  \def\listfigurename{\@ensure@RTL{لیستی وێنه‌کان}}%
+  \def\listtablename{\@ensure@RTL{لیستی خشته‌کان}}%
+  \def\indexname{\@ensure@RTL{پێنوێن}}%
+  \def\figurename{\@ensure@RTL{وێنه‌}}%
+  \def\tablename{\@ensure@RTL{خشتە}}%
+  \def\partname{\@ensure@RTL{به‌شی}}%
+  \def\enclname{\@ensure@RTL{هاوپێچ}}%
+  \def\ccname{\@ensure@RTL{روونووس}}%
+  \def\headtoname{\@ensure@RTL{بۆ}}%
+  \def\pagename{\@ensure@RTL{لاپه‌ڕه‌}}%
+  \def\seename{\@ensure@RTL{چاو لێکه‌ن}}%
+  \def\alsoname{\@ensure@RTL{هه‌روه‌ها چاو لێکه‌ن}}%
+  \def\proofname{\@ensure@RTL{سەلماندن}}%
+  \def\glossaryname{\@ensure@RTL{فه‌رهه‌نگۆک}}%
 }
 
-\def\farsinumber#1{%
+\def\datekurdish{%
+   \def\today{\@ensure@RTL{\kurdishnumber\day{ی}\space\kurdishmonth{\month}{ی}\space\kurdishnumber\year}}%
+}
+
+\newcommand{\kurdishnumerals}[2]{\kurdishnumber{#2}}
+
+\def\kurdishnumber#1{%
   \if@western@numerals
     \number#1%
   \else
@@ -101,39 +104,44 @@ and may look very wrong.}
   \fi
 }
 
-%\def\farsinum#1{\expandafter\farsinumber\csname c@#1\endcsname}
-%\def\farsibracenum#1{(\expandafter\farsinumber\csname c@#1\endcsname)}
-%\def\farsiornatebracenum#1{\char"FD3E\expandafter\farsinumber\csname c@#1\endcsname\char"FD3F}
-%\def\farsialph#1{\expandafter\@farsialph\csname c@#1\endcsname}
+%\def\kurdishnum#1{\expandafter\kurdishnumber\csname c@#1\endcsname}
+%\def\kurdishbracenum#1{(\expandafter\kurdishnumber\csname c@#1\endcsname)}
+%\def\kurdishornatebracenum#1{\char"FD3E\expandafter\kurdishnumber\csname c@#1\endcsname\char"FD3F}
+%\def\kurdishalph#1{\expandafter\@farsialph\csname c@#1\endcsname}
 
 \def\kurdish@numbers{%
-   \let\@latinalph\@alph%
-   \let\@latinAlph\@Alph%
    \let\@alph\abjad%
    \let\@Alph\abjad%
 }
+
 \def\nokurdish@numbers{%
   \let\@alph\@latinalph%
   \let\@Alph\@latinAlph%
-  }
+}
 
 \def\kurdish@globalnumbers{%
-   \let\orig@arabic\@arabic%
-   \let\@arabic\farsinumber%
-   % For some reason \thefootnote needs to be set separately:
-   \renewcommand\thefootnote{\protect\farsinumber{\c@footnote}}%
-   }
+   \let\@arabic\kurdishnumber%
+   \renewcommand\thefootnote{\localnumeral*{footnote}}%
+   \renewcommand\theequation{\localnumeral*{equation}}%
+}
 
-\def\nofarsi@globalnumbers{
-   \let\@arabic\orig@arabic%
+% Store original definition
+\let\xpg@save@arabic\@arabic
+
+\def\nokurdish@globalnumbers{
+   \let\@arabic\xpg@save@arabic%
    \renewcommand\thefootnote{\protect\number{\c@footnote}}%
-   }
+}
+
+% Save original \MakeUppercase definition
+\let\xpg@save@MakeUppercase\MakeUppercase
 
 \def\blockextras@kurdish{%
-   \let\@@MakeUppercase\MakeUppercase%
    \def\MakeUppercase##1{##1}%
-   }
+}
+
 \def\noextras@kurdish{%
-   \let\MakeUppercase\@@MakeUppercase%
-   }
+   \let\MakeUppercase\xpg@save@MakeUppercase%
+}
+
 \endinput

--- a/tex/gloss-portuges.ldf
+++ b/tex/gloss-portuges.ldf
@@ -19,7 +19,7 @@
   fontsetup=true,
 }
 
-\let\captionsportuges\captionsportuguese
-\let\dateportuges\dateportuguese
+\let\captionsportuges\captionsportuguese@portuges
+\let\dateportuges\dateportuguese@portuges
      
 \endinput

--- a/tex/gloss-portuges.ldf
+++ b/tex/gloss-portuges.ldf
@@ -1,4 +1,17 @@
-\ProvidesFile{gloss-portuges.ldf}[polyglossia: module for portuguese]
+\ProvidesFile{gloss-portuges.ldf}[polyglossia: module for portuguese (DEPRECATED!)]
+
+% We only provide this gloss for backwards compatibility. The name
+% 'portuges' was selected in accordance with babel (which probably
+% introduced it in 8.3 filename times). Since polyglossia uses full
+% English language names, we use 'portuguese' now.
+
+% FIXME: Once we support babel aliases (#112) this gloss can go.
+
+\xpg@warning{The language name 'portuges' is deprectated.\MessageBreak
+             Please use 'portuguese' instead.}
+
+\input{gloss-portuguese.ldf}
+
 \PolyglossiaSetup{portuges}{
   hyphennames={portuges,portuguese},
   hyphenmins={2,3},
@@ -6,36 +19,7 @@
   fontsetup=true,
 }
 
-\def\captionsportuges{%
-  \def\refname{Referências}%
-  \def\abstractname{Resumo}%
-  \def\bibname{Bibliografia}%
-  \def\prefacename{Prefácio}%
-  \def\chaptername{Capítulo}%
-  \def\appendixname{Apêndice}%
-  \def\contentsname{Conteúdo}%
-  \def\listfigurename{Lista de Figuras}%
-  \def\listtablename{Lista de Tabelas}%
-  \def\indexname{Índice}%
-  \def\figurename{Figura}%
-  \def\tablename{Tabela}%
-  %\def\thepart{}%
-  \def\partname{Parte}%
-  \def\pagename{Página}%
-  \def\seename{ver}%
-  \def\alsoname{ver também}%
-  \def\enclname{Anexo}%
-  \def\ccname{Com cópia a}%
-  \def\headtoname{Para}%
-  \def\proofname{Demonstração}%
-  \def\glossaryname{Glossário}%
-  }
-
-\def\dateportuges{%   
-  \def\today{\number\day\space de\space\ifcase\month\or
-    Janeiro\or Fevereiro\or Março\or Abril\or Maio\or Junho\or
-    Julho\or Agosto\or Setembro\or Outubro\or Novembro\or Dezembro\fi
-    \space de\space\number\year}%
-  }
+\let\captionsportuges\captionsportuguese
+\let\dateportuges\dateportuguese
      
 \endinput

--- a/tex/gloss-portuguese.ldf
+++ b/tex/gloss-portuguese.ldf
@@ -1,0 +1,41 @@
+\ProvidesFile{gloss-portuguese.ldf}[polyglossia: module for portuguese]
+\PolyglossiaSetup{portuguese}{
+  hyphennames={portuges,portuguese},
+  hyphenmins={2,3},
+  langtag=PTG,
+  fontsetup=true,
+}
+
+\def\captionsportuguese{%
+  \def\refname{Referências}%
+  \def\abstractname{Resumo}%
+  \def\bibname{Bibliografia}%
+  \def\prefacename{Prefácio}%
+  \def\chaptername{Capítulo}%
+  \def\appendixname{Apêndice}%
+  \def\contentsname{Conteúdo}%
+  \def\listfigurename{Lista de Figuras}%
+  \def\listtablename{Lista de Tabelas}%
+  \def\indexname{Índice}%
+  \def\figurename{Figura}%
+  \def\tablename{Tabela}%
+  %\def\thepart{}%
+  \def\partname{Parte}%
+  \def\pagename{Página}%
+  \def\seename{ver}%
+  \def\alsoname{ver também}%
+  \def\enclname{Anexo}%
+  \def\ccname{Com cópia a}%
+  \def\headtoname{Para}%
+  \def\proofname{Demonstração}%
+  \def\glossaryname{Glossário}%
+  }
+
+\def\dateportuguese{%   
+  \def\today{\number\day\space de\space\ifcase\month\or
+    Janeiro\or Fevereiro\or Março\or Abril\or Maio\or Junho\or
+    Julho\or Agosto\or Setembro\or Outubro\or Novembro\or Dezembro\fi
+    \space de\space\number\year}%
+  }
+     
+\endinput

--- a/tex/gloss-portuguese.ldf
+++ b/tex/gloss-portuguese.ldf
@@ -6,7 +6,33 @@
   fontsetup=true,
 }
 
-\def\captionsportuguese{%
+\def\portuguese@variant{portuges}
+\define@choicekey*+{portuguese}{variant}[\val\nr]{portuguese,brazilian}[portuguese]{%
+   \ifcase\nr\relax
+      % portuguese:
+      \gdef\portuguese@variant{portuges}%
+   \or
+      % brazilian:
+      \gdef\portuguese@variant{brazil}%
+      \xpg@ifdefined{brazil}{}%
+	    {\xpg@warning{No hyphenation patterns were loaded for "Portuguese (Brazil)"\MessageBreak
+	      I will use the standard patterns for Portuguese instead}%
+	    \adddialect\l@brazil\l@portuges\relax}%
+   \fi
+   \xpg@info{Option: portuguese, variant=\val}%
+}{\xpg@warning{Unknown portuguese variant `#1'}}
+
+
+\def\portuguese@language{%
+   \ifxetex
+      \language=\csname l@\portuguese@variant\endcsname
+   \fi
+   \ifluatex
+      \xpg@set@language@luatex@iv{\portuguese@variant}
+   \fi
+}%
+
+\def\captionsportuguese@portuges{%
   \def\refname{Referências}%
   \def\abstractname{Resumo}%
   \def\bibname{Bibliografia}%
@@ -19,7 +45,6 @@
   \def\indexname{Índice}%
   \def\figurename{Figura}%
   \def\tablename{Tabela}%
-  %\def\thepart{}%
   \def\partname{Parte}%
   \def\pagename{Página}%
   \def\seename{ver}%
@@ -29,13 +54,53 @@
   \def\headtoname{Para}%
   \def\proofname{Demonstração}%
   \def\glossaryname{Glossário}%
-  }
+}
 
-\def\dateportuguese{%   
+\def\captionsportuguese@brazil{%
+   \def\refname{Referências}%
+   \def\abstractname{Resumo}%
+   \def\bibname{Referências Bibliográficas}%
+   \def\prefacename{Prefácio}%
+   \def\chaptername{Capítulo}%
+   \def\appendixname{Apêndice}%
+   \def\contentsname{Sumário}%
+   \def\listfigurename{Lista de Figuras}%
+   \def\listtablename{Lista de Tabelas}%
+   \def\indexname{Índice Remissivo}%
+   \def\figurename{Figura}%
+   \def\tablename{Tabela}%
+   \def\partname{Parte}%
+   \def\pagename{Página}%
+   \def\seename{veja}%
+   \def\alsoname{veja também}%
+   \def\enclname{Anexo}%
+   \def\ccname{Cópia para}%
+   \def\headtoname{Para}%
+   \def\proofname{Demonstração}%
+   \def\glossaryname{Glossário}%
+}
+
+\def\captionsportuguese{%
+  \csname captionsportuguese@\portuguese@variant\endcsname%
+}
+
+\def\dateportuguese@portuges{%   
   \def\today{\number\day\space de\space\ifcase\month\or
     Janeiro\or Fevereiro\or Março\or Abril\or Maio\or Junho\or
     Julho\or Agosto\or Setembro\or Outubro\or Novembro\or Dezembro\fi
     \space de\space\number\year}%
-  }
+}
+
+
+\def\dateportuguese@brazil{%   
+   \def\today{\number\day\space de\space\ifcase\month\or
+      janeiro\or fevereiro\or março\or abril\or maio\or junho\or
+      julho\or agosto\or setembro\or outubro\or novembro\or dezembro%
+      \fi\space de\space\number\year}%
+}
+
+\def\dateportuguese{%
+  \csname dateportuguese@\portuguese@variant\endcsname%
+}
      
 \endinput

--- a/tex/polyglossia-french.lua
+++ b/tex/polyglossia-french.lua
@@ -15,7 +15,7 @@ local thickspace = 0.2777 -- 5/18
 local function activate_french_punct()
   polyglossia.activate_punct()
   polyglossia.clear_spaced_characters()
-	polyglossia.add_left_spaced_character(':',thickspace)
+  polyglossia.add_left_spaced_character(':',thickspace)
   polyglossia.add_left_spaced_character('!',thinspace)
   polyglossia.add_left_spaced_character('?',thinspace)
   polyglossia.add_left_spaced_character(';',thinspace)
@@ -35,8 +35,8 @@ local function deactivate_french_punct()
   -- safely uncomment the following line. Imagine the following case: you start
   -- a paragraph by some french text, then, in the same paragraph, you change
   -- the language to something else, and thus call the following line. This
-	-- means that, at the end of the paragraph, the function won't be in the
-	-- callback, so the beginning of the paragraph won't be processed by it.
+  -- means that, at the end of the paragraph, the function won't be in the
+  -- callback, so the beginning of the paragraph won't be processed by it.
   -- polyglossia.deactivate_punct()
 end
 

--- a/tex/polyglossia-french.lua
+++ b/tex/polyglossia-french.lua
@@ -1,0 +1,44 @@
+require('polyglossia-punct')
+
+-- How do we now, in Lua, what a \thinspace is? In the LaTeX source (latex.ltx)
+-- it is defined as:
+-- \def\thinspace{\leavevmode@ifvmode\kern .16667em }
+-- I see no way of seeing if it has been overriden or not. So we stick to this
+-- value.
+local thinspace = 0.16667 -- 1/6
+-- thickspace is defined in amsmath.sty as:
+-- \renewcommand{\;}{\tmspace+\thickmuskip{.2777em}}
+-- \let\thickspace\;
+-- Same problem as above, we stick to this fixed value.
+local thickspace = 0.2777 -- 5/18
+
+local function activate_french_punct()
+  polyglossia.activate_punct()
+  polyglossia.clear_spaced_characters()
+	polyglossia.add_left_spaced_character(':',thickspace)
+  polyglossia.add_left_spaced_character('!',thinspace)
+  polyglossia.add_left_spaced_character('?',thinspace)
+  polyglossia.add_left_spaced_character(';',thinspace)
+  polyglossia.add_left_spaced_character('‼',thinspace)
+  polyglossia.add_left_spaced_character('⁇',thinspace)
+  polyglossia.add_left_spaced_character('⁈',thinspace)
+  polyglossia.add_left_spaced_character('⁉',thinspace)
+  polyglossia.add_left_spaced_character('»',thinspace)
+  polyglossia.add_left_spaced_character('›',thinspace)
+  polyglossia.add_right_spaced_character('«',thinspace)
+  polyglossia.add_right_spaced_character('‹',thinspace)
+end
+
+-- So far, the following function is empty. It is provided for symmetry.
+local function deactivate_french_punct()
+  -- Though it would make compilation slightly faster, it is not possible to
+  -- safely uncomment the following line. Imagine the following case: you start
+  -- a paragraph by some french text, then, in the same paragraph, you change
+  -- the language to something else, and thus call the following line. This
+	-- means that, at the end of the paragraph, the function won't be in the
+	-- callback, so the beginning of the paragraph won't be processed by it.
+  -- polyglossia.deactivate_punct()
+end
+
+polyglossia.activate_french_punct   = activate_french_punct
+polyglossia.deactivate_french_punct = deactivate_french_punct

--- a/tex/polyglossia-frpt.lua
+++ b/tex/polyglossia-frpt.lua
@@ -6,9 +6,9 @@ local priority_in_callback = luatexbase.priority_in_callback
 
 local get_quad = luaotfload.aux.get_quad -- needs luaotfload > 20130516
 
-local next, type = next, type
+local next = next
 
-local nodes, fonts, node = nodes, fonts, node
+local nodes, node = nodes, node
 
 local nodecodes          = nodes.nodecodes
 
@@ -31,22 +31,13 @@ if not end_of_math then -- luatex < .76
 end
 
 -- node types according to node.types()
-local glue_code         = nodecodes.glue
-local glue_spec_code    = nodecodes.glue_spec
-local glyph_code        = nodecodes.glyph
-local penalty_code      = nodecodes.penalty
-local kern_code         = nodecodes.kern
+local glue_code    = nodecodes.glue
+local glyph_code   = nodecodes.glyph
+local penalty_code = nodecodes.penalty
+local kern_code    = nodecodes.kern
 
 -- we make a new node, so that we can copy it later on
-local penalty_node   = new_node(penalty_code)
-penalty_node.penalty = 10000
-
-local function get_penalty_node()
-  return node_copy(penalty_node)
-end
-
--- same for glue node
-local kern_node       = new_node(kern_code)
+local kern_node = new_node(kern_code)
 
 local function get_kern_node(dim)
   local n = node_copy(kern_node)
@@ -56,17 +47,18 @@ end
 
 -- we have here all possible space characters, referenced by their
 -- unicode slot number, taken from char-def.lua
-local space_chars = {[32]=1, [160]=1, [5760]=1, [6158]=1, [8192]=1, [8193]=1, [8194]=1, [8195]=1, 
-  [8196]=1, [8197]=1, [8198]=1, [8199]=1, [8200]=1, [8201]=1, [8202]=1, [8239]=1, [8287]=1, [12288]=1}
+local space_chars = {[32] = true, [160] = true, [5760] = true, [6158] = true, [8192] = true, [8193] = true,
+  [8194] = true, [8195] = true, [8196] = true, [8197] = true, [8198] = true, [8199] = true, [8200] = true,
+  [8201] = true, [8202] = true, [8239] = true, [8287] = true, [12288] = true}
 
 -- from nodes-tst.lua, adapted
-local function somespace(n,all)
+local function somespace(n)
     if n then
         local id = n.id
         if id == glue_code then
-            return (all or (n.spec.width ~= 0)) and glue_code
+            return glue_code
         elseif id == kern_code then
-            return (all or (n.kern ~= 0)) and kern_code
+            return kern_code
         elseif id == glyph_code then
             if space_chars[n.char] then
                 return true
@@ -95,48 +87,21 @@ end
 
 local xpgfrptattr = luatexbase.attributes['xpg@frpt']
 
-local left=1
-local right=2
-local byte = unicode.utf8.byte
-
 -- Now there is a good question: how do we now, in lua, what a \thinspace is?
 -- In the LaTeX source (ltspace.dtx) it is defined as:
 -- \def\thinspace{\kern .16667em }. I see no way of seeing if it has been
 -- overriden or not... So we stick to this value.
-local thinspace  = 0.16667 
+local thinspace  = 0.16667
 -- thickspace is defined in amsmath.sty as:
 -- \renewcommand{\;}{\mspace+\thickmuskip{.2777em}}. Same problem as above, we
 -- stick to this fixed value.
 local thickspace = 0.2777 -- 5/18
 
-local mappings =  {
- [byte(':')] = {left,  thickspace}, --really?
- [byte('!')] = {left,  thinspace},
- [byte('?')] = {left,  thinspace},
- [byte(';')] = {left,  thinspace},
- [byte('‼')] = {left,  thinspace},
- [byte('⁇')] = {left,  thinspace},
- [byte('⁈')] = {left,  thinspace},
- [byte('⁉')] = {left,  thinspace},
- [byte('»')] = {left,  thinspace},
- [byte('›')] = {left,  thinspace},
- [byte('«')] = {right, thinspace}, 
- [byte('‹')] = {right, thinspace}, 
- }
+local left_space = {[':'] = thickspace, ['!'] = thinspace, ['?'] = thinspace, [';'] = thinspace, ['‼'] = thinspace,
+  ['⁇'] = thinspace, ['⁈'] = thinspace, ['⁉'] = thinspace, ['»'] = thinspace, ['›'] = thinspace}
+local right_space = {['«'] = thinspace, ['‹'] = thinspace}
 
-local function set_spacings(thinsp, thicksp)
-  for _, m in pairs(mappings) do
-    if m[2] == thinspace then
-      m[2] = thinsp
-    elseif m[2] == thickspace then
-      m[2] = thicksp
-    end
-  end
-  thickspace = thicksp
-  thinspace = thinsp
-end
-
--- from typo-spa.lua
+-- from typo-spa.lua, adapted
 local function process(head)
     local done = false
     local start = head
@@ -147,47 +112,38 @@ local function process(head)
         if id == glyph_code then
             local attr = has_attribute(start, xpgfrptattr)
             if attr and attr > 0 then
-                local char = start.char
-                local map = mappings[char]
-                --node.unset_attribute(start, xpgfrptattr) -- needed?
-                if map then
+                local char = utf8.char(start.char) -- requires Lua 5.3
+                if left_space[char] or right_space[char] then
                     local quad = get_quad(start.font) -- might be optimized
                     local prev = start.prev
-                    if map[1] == left and prev then
+                    if left_space[char] and prev then
                         local prevprev = prev.prev
-                        local somespace = somespace(prev,true)
+                        if somespace(prev) then
                         -- TODO: there is a question here: do we override a preceding space or not?...
-                        if somespace then
-                            local somepenalty = somepenalty(prevprev,10000)
-                            if somepenalty then
+                            if somepenalty(prevprev,10000) then
                                 head = remove_node(head,prev)
                                 head = remove_node(head,prevprev)
                             else
                                 head = remove_node(head,prev)
                             end
                         end
-                        insert_node_before(head,start,get_penalty_node())
-                        insert_node_before(head,start,get_kern_node(map[2]*quad))
+                        insert_node_before(head,start,get_kern_node(left_space[char]*quad))
                         done = true
                     end
                     local next = start.next
-                    if map[1] == right and next then
+                    if right_space[char] and next then
                         local nextnext = next.next
-                        local somepenalty = somepenalty(next,10000)
-                        if somepenalty then
-                            local somespace = somespace(nextnext,true)
-                            if somespace then
+                        if somepenalty(next,10000) then
+                            if somespace(nextnext) then
                                 head = remove_node(head,next)
                                 head = remove_node(head,nextnext)
                             end
                         else
-                            local somespace = somespace(next,true)
-                            if somespace then
+                            if somespace(next) then
                                 head = remove_node(head,next)
                             end
                         end
-                        insert_node_after(head,start,get_kern_node(map[2]*quad))
-                        insert_node_after(head,start,get_penalty_node())
+                        insert_node_after(head,start,get_kern_node(right_space[char]*quad))
                         done = true
                     end
                 end
@@ -219,6 +175,3 @@ end
 
 polyglossia.activate_frpt    = activate
 polyglossia.desactivate_frpt = desactivate
-polyglossia.set_spacings     = set_spacings
-polyglossia.thinspace        = thinspace
-polyglossia.thickspace       = thickpace

--- a/tex/polyglossia-latin.lua
+++ b/tex/polyglossia-latin.lua
@@ -1,0 +1,39 @@
+require('polyglossia-punct')
+
+-- For ecclesiastic Latin (and sometimes for Italian) a very small space is
+-- used for the punctuation. The ecclesiastic package uses a space of
+-- 0.3\fontdimen2, where \fontdimen2 is a interword space, which is typically
+-- between 1/4 and 1/3 of a quad. We choose a half of a \thinspace here.
+local hairspace = 0.08333 -- 1/12 quad
+
+local function activate_latin_punct()
+  polyglossia.activate_punct()
+  polyglossia.clear_spaced_characters()
+  polyglossia.add_left_spaced_character(':',hairspace)
+  polyglossia.add_left_spaced_character('!',hairspace)
+  polyglossia.add_left_spaced_character('?',hairspace)
+  polyglossia.add_left_spaced_character(';',hairspace)
+  polyglossia.add_left_spaced_character('‼',hairspace)
+  polyglossia.add_left_spaced_character('⁇',hairspace)
+  polyglossia.add_left_spaced_character('⁈',hairspace)
+  polyglossia.add_left_spaced_character('⁉',hairspace)
+  polyglossia.add_left_spaced_character('»',hairspace)
+  polyglossia.add_left_spaced_character('›',hairspace)
+  polyglossia.add_right_spaced_character('«',hairspace)
+  polyglossia.add_right_spaced_character('‹',hairspace)
+end
+
+-- So far, the following function is empty. It is provided for symmetry.
+local function deactivate_latin_punct()
+  -- Though it would make compilation slightly faster, it is not possible to
+  -- safely uncomment the following line. Imagine the following case: you start
+  -- a paragraph by some ecclesiastical Latin text, then, in the same
+  -- paragraph, you change the language to something else, and thus call the
+  -- following line. This means that, at the end of the paragraph, the function
+  -- won't be in the callback, so the beginning of the paragraph won't be
+  -- processed by it.
+  -- polyglossia.deactivate_punct()
+end
+
+polyglossia.activate_latin_punct   = activate_latin_punct
+polyglossia.deactivate_latin_punct = deactivate_latin_punct

--- a/tex/polyglossia.lua
+++ b/tex/polyglossia.lua
@@ -84,8 +84,8 @@ else
   end
 end
 
-local function load_frpt()
-    require('polyglossia-frpt')
+local function load_punct()
+    require('polyglossia-punct')
 end
 
 local function load_tibt_eol()
@@ -173,7 +173,7 @@ polyglossia.loadlang = loadlang
 polyglossia.select_language = select_language
 polyglossia.set_default_language = set_default_language
 polyglossia.check_char = check_char
-polyglossia.load_frpt = load_frpt
+polyglossia.load_punct = load_punct
 polyglossia.load_tibt_eol = load_tibt_eol
 polyglossia.newloader = newloader
 polyglossia.newloader_loaded_languages = newloader_loaded_languages

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -804,51 +804,63 @@
   \csgdef{#1@font@rm}{%
     \cs_if_exist_use:cF{#1font}
       {
+       \providetoggle{#1@use@script@font}%
        \str_if_eq:nnTF{\prop_item:Nn{\polyglossia@langsetup}{#1/script}}{\prop_item:Nn{\polyglossia@langsetup}{#1/language}}
         {\rmfamilylatin}%
         {\cs_if_exist_use:cTF{\prop_item:Nn{\polyglossia@langsetup}{#1/lcscript} font}
           {
-            \polyglossia@addfontfeature@script:xx{\prop_item:Nn{\polyglossia@langsetup}{#1/scripttag}}
-                                                 {\prop_item:Nn{\polyglossia@langsetup}{#1/script}}
+             \toggletrue{#1@use@script@font}%
            }
            {
              \rmfamilylatin
            }
        }
+       \iftoggle{#1@use@script@font}{}{%
+           \polyglossia@addfontfeature@script:xx{\prop_item:Nn{\polyglossia@langsetup}{#1/scripttag}}
+                                                 {\prop_item:Nn{\polyglossia@langsetup}{#1/script}}
+       }%
        \polyglossia@addfontfeature@language:xx{\prop_item:Nn{\polyglossia@langsetup}{#1/langtag}}
                                               {\prop_item:Nn{\polyglossia@langsetup}{#1/language}}
       }}%
   \csgdef{#1@font@sf}{%
     \cs_if_exist_use:cF{#1fontsf}%
       {
+       \providetoggle{#1@use@script@fontsf}%
        \str_if_eq:nnTF{\prop_item:Nn{\polyglossia@langsetup}{#1/script}}{\prop_item:Nn{\polyglossia@langsetup}{#1/language}}
         {\sffamilylatin}%
         {\cs_if_exist_use:cTF{\prop_item:Nn{\polyglossia@langsetup}{#1/lcscript} fontsf}
           {
-            \polyglossia@addfontfeature@script:xx{\prop_item:Nn{\polyglossia@langsetup}{#1/scripttag}}
-                                                 {\prop_item:Nn{\polyglossia@langsetup}{#1/script}}
+             \toggletrue{#1@use@script@fontsf}%
            }
            {
              \sffamilylatin
            }
        }
+       \iftoggle{#1@use@script@fontsf}{}{%
+           \polyglossia@addfontfeature@script:xx{\prop_item:Nn{\polyglossia@langsetup}{#1/scripttag}}
+                                                 {\prop_item:Nn{\polyglossia@langsetup}{#1/script}}
+       }%
        \polyglossia@addfontfeature@language:xx{\prop_item:Nn{\polyglossia@langsetup}{#1/langtag}}
                                               {\prop_item:Nn{\polyglossia@langsetup}{#1/language}}
       }}%
   \csgdef{#1@font@tt}{%
     \cs_if_exist_use:cF{#1fonttt}%
       {
+       \providetoggle{#1@use@script@fonttt}%
        \str_if_eq:nnTF{\prop_item:Nn{\polyglossia@langsetup}{#1/script}}{\prop_item:Nn{\polyglossia@langsetup}{#1/language}}
        {\ttfamilylatin}%
        {\cs_if_exist_use:cTF{\prop_item:Nn{\polyglossia@langsetup}{#1/lcscript} fonttt}
            {
-            \polyglossia@addfontfeature@script:xx{\prop_item:Nn{\polyglossia@langsetup}{#1/scripttag}}
-                                                 {\prop_item:Nn{\polyglossia@langsetup}{#1/script}}
+             \toggletrue{#1@use@script@fonttt}%
            }
            {
              \ttfamilylatin
            }
        }
+       \iftoggle{#1@use@script@fonttt}{}{%
+           \polyglossia@addfontfeature@script:xx{\prop_item:Nn{\polyglossia@langsetup}{#1/scripttag}}
+                                                 {\prop_item:Nn{\polyglossia@langsetup}{#1/script}}
+       }%
        \polyglossia@addfontfeature@language:xx{\prop_item:Nn{\polyglossia@langsetup}{#1/langtag}}
                                               {\prop_item:Nn{\polyglossia@langsetup}{#1/language}}
       }}%

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -486,8 +486,14 @@
 
 
 % call the language
+% #3 is the numeral to print
+% #4 is the mainlanguage (should be expanded)
+% #5 is the current language (should be expanded)
+% #2 is the option list (should be expanded)
+% #6 is the name of the field to use
+% #1 is the language used
 \cs_new:Nn \polyglossia_localnumeral_langlang:nnnnnn {
-  \use:c {\prop_item:Nn \polyglossia@langsetup  {#1/#5}} {#2} {#3}
+  \use:c {\prop_item:Nn \polyglossia@langsetup  {#1/#6}} {#2} {#3}
 }
 
 

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -448,7 +448,7 @@
 % #1 is the option list (should be expanded)
 % #5 is the name of the field to use
 \cs_new:Nn \polyglossia_localnumeral_mainlang:nnnnn {
-  \use:c {\prop_item:Nn \polyglossia@langsetup  {#3/#5}} {#1} {#2}
+  \foreignlanguage{#3}{\use:c {\prop_item:Nn \polyglossia@langsetup  {#3/#5}} {#1} {#2}}
 }
 
 
@@ -493,7 +493,7 @@
 % #6 is the name of the field to use
 % #1 is the language used
 \cs_new:Nn \polyglossia_localnumeral_langlang:nnnnnn {
-  \use:c {\prop_item:Nn \polyglossia@langsetup  {#1/#6}} {#2} {#3}
+   \foreignlanguage{#1}{\use:c {\prop_item:Nn \polyglossia@langsetup  {#1/#6}} {#2} {#3}}
 }
 
 


### PR DESCRIPTION
In preparation of the new Latin language file, I have revised the Lua code for French punctuation spacing.
I have split the `polyglossia-frpt.lua` file in two: a generic part (`polyglossia-punct.lua`) usable for any language, and a specific French part (`polyglossia-french.lua`) with the settings for the spacings for French.
Furthermore, I have contributed a Lua file `polyglossia-latin.lua` with the settings for ecclesiastical Latin (inspired by the `ecclesiastic` package, an addition to `babel-latin`, and the existing, but undocumented XeTeX support of ecclesiastical Latin by `polyglossia`). A similar file could be created for Sanskrit.
Unfortunately, I was not able to complete the revision of `gloss-latin.ldf` because I ran into a serious problem trying to implement an active apostrophe (as provided by the `ecclesiastic` package).
[Look here](https://tex.stackexchange.com/questions/508253/apostrophe-in-math-formula-prevents-luatex-compilation-for-slovak), if you are interested.