### PR TITLE
support luahbtex; change regarding \@chapapp

### DIFF
--- a/tex/gloss-korean.ldf
+++ b/tex/gloss-korean.ldf
@@ -147,15 +147,22 @@
     }
 \fi
 
-\def\blockextras@korean{%
-    \inlineextras@korean
+\def\korean@redefine@chapapp{%
     \ifdefined\@chapapp
-        \long\def\@tmpa{\chaptername}\def\@tmpb{\chaptername}%
+        \long\def\@tmpa{\chaptername}\def\@tmpb{\chaptername}% exclude appendix
         \ifnum0\ifx\@chapapp\@tmpa1\else\ifx\@chapapp\@tmpb1\fi\fi>\z@
             \let\xpg@orig@@chapapp\@chapapp
             \def\@chapapp##1##2{\koreanTHEname ##1##2##1\chaptername}%
         \fi
     \fi
+}
+\@ifclassloaded{book}{}{\@ifclassloaded{report}{}{%
+    \let\korean@redefine@chapapp\relax
+}}
+
+\def\blockextras@korean{%
+    \inlineextras@korean
+    \korean@redefine@chapapp
 }
 
 \def\noextras@korean@common{%

--- a/tex/polyglossia-korean.lua
+++ b/tex/polyglossia-korean.lua
@@ -420,14 +420,19 @@ local function reorder_tm (head)
     local curr, tone = node.slide(head)
     while curr do
         if curr.id == glyph_id and node.has_attribute(curr, attr_korean) then
-            local c, wd = curr.char or 0, curr.width or 0
-            if (c == 0x302E or c == 0x302F) and wd > 0 then
-                tone = curr
-            elseif tone and not nobr_before[c] then
-                head = node.remove(head, tone)
-                tone.next, tone.prev = nil, nil
-                head, curr = node.insert_before(head, curr, tone)
+            local f = font.getfont(curr.font) or font.fonts[curr.font]
+            if f and f.hb then -- harfbuzz do the right thing
                 tone = nil
+            else
+                local c, wd = curr.char or 0, curr.width or 0
+                if (c == 0x302E or c == 0x302F) and wd > 0 then
+                    tone = curr
+                elseif tone and not nobr_before[c] then
+                    head = node.remove(head, tone)
+                    tone.next, tone.prev = nil, nil
+                    head, curr = node.insert_before(head, curr, tone)
+                    tone = nil
+                end
             end
         end
         curr = curr.prev


### PR DESCRIPTION
* Currently the function `reorder_tm` in polyglossia-korean.lua does the reordering of a Hangul Tone Mark (U+302E or U+302F) node from the last to the first position of a syllable. This is not necessary, or even will malfunction, when `Renderer=OpenType` font option is used with `LuaHBTeX` engine. So the relevent check has been added.
* Redefinition of `\@chapapp` for Korean-style chapter heading now works only upon `book` or `report` class, as the redefinition does not work with, say, `memoir`. On memoir class, users can easily make their own chpater styles.