### PR TITLE
Remove superfluous argument in call to \xpg@set@group@aux (#379)

### DIFF
--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -2088,7 +2088,7 @@
            {\ifvmode\else\booltrue{xpg@noset@groups}\fi}% RTL -> LTR
        }%
   \fi%
-  \ifbool{xpg@noset@groups}{}{\xpg@set@group@aux{#2}}%
+  \ifbool{xpg@noset@groups}{}{\xpg@set@group@aux}%
   \selectlanguage[#1]{#2}%
 }
 {\ifbool{xpg@noset@groups}{}{\xpg@unset@group@aux}}


### PR DESCRIPTION
The relevant change to the argument structure of `\xpg@set@group@aux` is in c5adc4eef3c5297797355048b1799d251e8b9e4b.

This should resolve #379.