### PR TITLE
Fix l·l spacing in catalan

### DIFF
--- a/tex/gloss-catalan.ldf
+++ b/tex/gloss-catalan.ldf
@@ -45,14 +45,19 @@
     \xpg@if@char@available{00B7}%
           {\setbox2\hbox{\char"00B7}}%
           {\setbox2\hbox{.}}%
+    \setbox3\hbox{.}%
     \advance\raiselldim by \the\fontdimen5\the\font
     \advance\raiselldim by -\ht2%
     \leftllkern=-.25\wd0%
     \advance\leftllkern by \wd1%
     \advance\leftllkern by -\wd0%
+    \advance\leftllkern by -0.5\wd2%
+    \advance\leftllkern by 0.5\wd3%
     \rightllkern=-.25\wd0%
     \advance\rightllkern by -\wd1%
     \advance\rightllkern by \wd0%
+    \advance\rightllkern by -0.5\wd2%
+    \advance\rightllkern by 0.5\wd3%
     \allowhyphens\discretionary{l-}{l}%
     {\hbox{l}\kern\leftllkern\xpg@raiseddot%
       \kern\rightllkern\hbox{l}}\allowhyphens
@@ -68,15 +73,20 @@
     \xpg@if@char@available{00B7}%
           {\setbox2\hbox{\char"00B7}}%
           {\setbox2\hbox{.}}%
+    \setbox3\hbox{.}%
     \advance\raiselldim by .5\ht0%
     \advance\raiselldim by -.5\ht2%
     \leftllkern=-.125\wd0%
     \advance\leftllkern by \wd1%
     \advance\leftllkern by -\wd0%
+    \advance\leftllkern by -0.5\wd2%
+    \advance\leftllkern by 0.5\wd3%
     \rightllkern=-\wd0%
     \divide\rightllkern by 6%
     \advance\rightllkern by -\wd1%
     \advance\rightllkern by \wd0%
+    \advance\rightllkern by -0.5\wd2%
+    \advance\rightllkern by 0.5\wd3%
     \allowhyphens\discretionary{L-}{L}%
     {\hbox{L}\kern\leftllkern\xpg@raiseddot%
       \kern\rightllkern\hbox{L}}\allowhyphens

--- a/tex/gloss-catalan.ldf
+++ b/tex/gloss-catalan.ldf
@@ -41,12 +41,12 @@
     \csname normal@char\string"\endcsname l%
   \else
     \leftllkern=0pt\rightllkern=0pt\raiselldim=0pt%
-    \setbox0\hbox{l}\setbox1\hbox{l\/}%
+    \setbox0\hbox{l}%
     \xpg@if@char@available{00B7}%
-          {\setbox2\hbox{\char"00B7}}%
-          {\setbox2\hbox{.}}%
+          {\setbox2\hbox{\char"00B7}\setbox1\hbox{l}}%
+          {\setbox2\hbox{.}\setbox1\hbox{l\/}}%
     \setbox3\hbox{.}%
-    \advance\raiselldim by \the\fontdimen5\the\font
+    \advance\raiselldim by \the\fontdimen5\the\font%
     \advance\raiselldim by -\ht2%
     \leftllkern=-.25\wd0%
     \advance\leftllkern by \wd1%
@@ -69,10 +69,10 @@
     \csname normal@char\string"\endcsname L%
   \else
     \leftllkern=0pt\rightllkern=0pt\raiselldim=0pt%
-    \setbox0\hbox{L}\setbox1\hbox{L\/}%
+    \setbox0\hbox{L}%
     \xpg@if@char@available{00B7}%
-          {\setbox2\hbox{\char"00B7}}%
-          {\setbox2\hbox{.}}%
+          {\setbox2\hbox{\char"00B7}\setbox1\hbox{L}}%
+          {\setbox2\hbox{.}\setbox1\hbox{L\/}}%
     \setbox3\hbox{.}%
     \advance\raiselldim by .5\ht0%
     \advance\raiselldim by -.5\ht2%


### PR DESCRIPTION
Code for catalan geminated l (l·l) was copied from babel. However, babel spaced the middle dot assuming it was a regular dot. Polyglossia changes the dot for U00B7, which breaks spacing. I have added a couple of lines of code so that the spacing calculated for a dot works again.