### PR TITLE
Remove renewed definition of \labelitemii

### DIFF
--- a/tex/gloss-marathi.ldf
+++ b/tex/gloss-marathi.ldf
@@ -138,14 +138,4 @@ and may look very wrong.}
   \let\@Roman\xpg@save@Roman
 }
 
-\def\blockextras@marathi{%
-  \renewcommand{\labelitemii}{$\rightarrow$}%
-}
-
-\let\xpg@orig@labelitemii\labelitemii
-
-\def\noextras@marathi{%
-  \let\labelitemii\xpg@orig@labelitemii%
-}
-
 \endinput


### PR DESCRIPTION
This redefinition gives error with `\documentclass{beamer}`, hence it should be removed.