### PR TITLE
Use Harfbuzz renderer by default with LuaTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # THE POLYGLOSSIA PACKAGE v1.49
 ## Multilingual typesetting with XeLaTeX and LuaLaTeX
 
-This package provides an alternative to Babel for users of XeLaTeX and LuaLaTeX
-(with a few languages incompletely supported for the latter). This version
-includes support for over 70 different languages, some of which in different
-regional or national varieties, or using a different writing system.
+This package provides an alternative to Babel for users of XeLaTeX and LuaLaTeX.
+This version includes support for over 70 different languages, some of which in
+different regional or national varieties, or using a different writing system.
 
 Polyglossia makes it possible to automate the following tasks:
 

--- a/doc/Changelog
+++ b/doc/Changelog
@@ -1,7 +1,9 @@
 1.50 (forthcoming)
 
 New features:
-
+  * Polyglossia now uses the Harfbuzz renderer by default with LuaTeX
+    output. This brings LuaTeX on par with XeTeX for all scripts (#337).
+    The renderer can be changed via the new global luatexrenderer option.
 
 Bug fixes:
 

--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -67,6 +67,12 @@
      \xpgvalue{=} \meta{code} (default value: \texttt{#3})\par%
 }
 
+% arguments: #1 version number, #2 key name, #3 value type, #4 default value
+\NewDocumentCommand\xpgoptkey{ommo}{%
+	\xpgoption{#2}\IfValueT{#1}{\new{#1}}
+	\xpgvalue{=} \meta{#3} (default value: \texttt{#4})\par%
+}
+
 %% Sidenotes  << copied from fontspec.dtx
 \newcommand\new[1]{%
   \edef\thisversion{v#1}%
@@ -141,7 +147,7 @@
 \section{Introduction}
 
 \pkg{Polyglossia} is a package for facilitating multilingual typesetting with
-\XeLaTeX\ and (with some exceptions) \LuaLaTeX. Basically, it
+\XeLaTeX\ and \LuaLaTeX. Basically, it
 can be used as an alternative to \pkg{babel} for performing the following
 tasks automatically:
 
@@ -540,11 +546,19 @@ Table~\ref{tab:BCP47-polyglossia} lists the currently supported tags.
 		option \xpgoption{nolocalmarks} which used to switch off the previous default, and
 		now equals the default, is still available.
 
-	\item \xpgoption{quiet} turns off most info messages and some of the warnings issued
-		by \LaTeX, \pkg{fontspec} and \pkg{polyglossia}.
+    \item \xpgoptkey[1.50]{luatexrenderer}{renderer}[Harfbuzz] determines which font renderer is used
+        with \LuaTeX\ output. The correct font renderer is essential particularly for non-Latin scripts.
+        By default, \pkg{polyglossia} uses the \xpgvalue{Harfbuzz} renderer that has been introduced to
+        \LuaTeX\ in 2019 (\TeX Live 2020), as this gives the best results generally. If you want to use
+        a different renderer, you can specify this here (or individually for specific fonts via the optional
+        argument of the font selection commands). Please refer to the \pkg{fontspec} manual for supported
+        values and for details on how to change the renderer for individual fonts.\\
+        \xpgoption{luatexrenderer=none} disables \pkg{polyglossia}'s automatic renderer setting.
+
+	\item \xpgboolkeytrue{verbose} determines whether info messages and (some of the) warnings issued
+		by \LaTeX, \pkg{fontspec} and \pkg{polyglossia} are output.
 \end{itemize}
 
-\pagebreak
 \section{Language-switching commands}\label{languageswitching}
 
 \subsection{Recommended commands}\label{sec:langcmds}

--- a/tex/gloss-arabic.ldf
+++ b/tex/gloss-arabic.ldf
@@ -1,10 +1,4 @@
 \ProvidesFile{gloss-arabic.ldf}[polyglossia: module for arabic]
-\ifluatex
-  \xpg@warning{Arabic is not supported with LuaTeX.\MessageBreak
-I will proceed with the compilation, but\MessageBreak
-the output is not guaranteed to be correct\MessageBreak
-and may look very wrong.}
-\fi
 \RequireBidi
 \RequirePackage{arabicnumbers}
 \RequirePackage{hijrical}

--- a/tex/gloss-bengali.ldf
+++ b/tex/gloss-bengali.ldf
@@ -3,13 +3,6 @@
 
 \ProvidesFile{gloss-bengali.ldf}[polyglossia: module for bengali]
 
-\ifluatex
-  \xpg@warning{Bengali is not supported with LuaTeX.\MessageBreak
-               I will proceed with the compilation, but\MessageBreak
-               the output is not guaranteed to be correct\MessageBreak
-               and may look very wrong.}
-\fi
-
 \RequirePackage{devanagaridigits}
 \RequirePackage{bengalidigits}
 

--- a/tex/gloss-divehi.ldf
+++ b/tex/gloss-divehi.ldf
@@ -1,10 +1,5 @@
 \ProvidesFile{gloss-divehi.ldf}[polyglossia: module for divehi]
-\ifluatex
-  \xpg@warning{Divehi is not supported with LuaTeX.\MessageBreak
-I will proceed with the compilation, but\MessageBreak
-the output is not guaranteed to be correct\MessageBreak
-and may look very wrong.}
-\fi
+
 \RequireBidi
 \PolyglossiaSetup{divehi}{
   bcp47=dv,

--- a/tex/gloss-hebrew.ldf
+++ b/tex/gloss-hebrew.ldf
@@ -1,10 +1,5 @@
 \ProvidesFile{gloss-hebrew.ldf}[polyglossia: module for hebrew]
-\ifluatex
-  \xpg@warning{Hebrew is not supported with LuaTeX.\MessageBreak
-I will proceed with the compilation, but\MessageBreak
-the output is not guaranteed to be correct\MessageBreak
-and may look very wrong.}
-\fi
+
 \RequireBidi
 \RequirePackage{hebrewcal}
 

--- a/tex/gloss-kannada.ldf
+++ b/tex/gloss-kannada.ldf
@@ -17,12 +17,7 @@
 %
 % This work consists of the file gloss-kannada.ldf
 \ProvidesFile{gloss-kannada.ldf}[polyglossia: module for kannada]
-\ifluatex
-  \xpg@warning{Kannada is not supported with LuaTeX.\MessageBreak
-I will proceed with the compilation, but\MessageBreak
-the output is not guaranteed to be correct\MessageBreak
-and may look very wrong.}
-\fi
+
 \PolyglossiaSetup{kannada}{
   bcp47=kn,
   script=Kannada,

--- a/tex/gloss-lao.ldf
+++ b/tex/gloss-lao.ldf
@@ -1,10 +1,5 @@
 \ProvidesFile{gloss-lao.ldf}[polyglossia: module for Lao]
-\ifluatex
-  \xpg@warning{Lao is not supported with LuaTeX.\MessageBreak
-I will proceed with the compilation, but\MessageBreak
-the output is not guaranteed to be correct\MessageBreak
-and may look very wrong.}
-\fi
+
 \PolyglossiaSetup{lao}{
   bcp47=lo,
   script=Lao,

--- a/tex/gloss-malayalam.ldf
+++ b/tex/gloss-malayalam.ldf
@@ -1,10 +1,5 @@
 ﻿\ProvidesFile{gloss-malayalam.ldf}[polyglossia: module for malayalam]
-\ifluatex
-  \xpg@warning{Malayalam is not supported with LuaTeX.\MessageBreak
-I will proceed with the compilation, but\MessageBreak
-the output is not guaranteed to be correct\MessageBreak
-and may look very wrong.}
-\fi
+
 % Translations provided by Kevin & Siji, 01-11-2009
 
 \PolyglossiaSetup{malayalam}{

--- a/tex/gloss-marathi.ldf
+++ b/tex/gloss-marathi.ldf
@@ -3,12 +3,7 @@
 % TODO implement Hindu calendar (not used in day-to-day practice)
 
 \ProvidesFile{gloss-marathi.ldf}[polyglossia: module for marathi]
-\ifluatex
-  \xpg@warning{Marathi is not supported with LuaTeX.\MessageBreak
-I will proceed with the compilation, but\MessageBreak
-the output is not guaranteed to be correct\MessageBreak
-and may look very wrong.}
-\fi
+
 \RequirePackage{devanagaridigits}
 
 \PolyglossiaSetup{marathi}{

--- a/tex/gloss-persian.ldf
+++ b/tex/gloss-persian.ldf
@@ -1,10 +1,5 @@
 \ProvidesFile{gloss-persian.ldf}[polyglossia: module for persian]
-\ifluatex
-  \xpg@warning{Persian is not supported with LuaTeX.\MessageBreak
-I will proceed with the compilation, but\MessageBreak
-the output is not guaranteed to be correct\MessageBreak
-and may look very wrong.}
-\fi
+
 \RequireBidi
 \RequirePackage{arabicnumbers}
 \RequirePackage{farsical}

--- a/tex/gloss-sanskrit.ldf
+++ b/tex/gloss-sanskrit.ldf
@@ -1,10 +1,4 @@
 \ProvidesFile{gloss-sanskrit.ldf}[polyglossia: module for sanskrit]
-\ifluatex
-  \xpg@warning{Sanskrit is not supported with LuaTeX.\MessageBreak
-I will proceed with the compilation, but\MessageBreak
-the output is not guaranteed to be correct\MessageBreak
-and may look very wrong.}
-\fi
 
 \RequirePackage{devanagaridigits}
 

--- a/tex/gloss-syriac.ldf
+++ b/tex/gloss-syriac.ldf
@@ -1,10 +1,5 @@
 \ProvidesFile{gloss-syriac.ldf}[polyglossia: module for syriac]
-\ifluatex
-  \xpg@warning{Syriac is not supported with LuaTeX.\MessageBreak
-I will proceed with the compilation, but\MessageBreak
-the output is not guaranteed to be correct\MessageBreak
-and may look very wrong.}
-\fi
+
 \RequireBidi
 \RequirePackage{arabicnumbers}
 

--- a/tex/gloss-tamil.ldf
+++ b/tex/gloss-tamil.ldf
@@ -1,10 +1,5 @@
 ﻿\ProvidesFile{gloss-tamil.ldf}[polyglossia: module for tamil]
-\ifluatex
-  \xpg@warning{Tamil is not supported with LuaTeX.\MessageBreak
-I will proceed with the compilation, but\MessageBreak
-the output is not guaranteed to be correct\MessageBreak
-and may look very wrong.}
-\fi
+
 % Translations provided by Kevin & Siji, 01-11-2009
 
 \PolyglossiaSetup{tamil}{

--- a/tex/gloss-telugu.ldf
+++ b/tex/gloss-telugu.ldf
@@ -1,10 +1,5 @@
 \ProvidesFile{gloss-telugu.ldf}[polyglossia: module for telugu]
-\ifluatex
-  \xpg@warning{Telugu is not supported with LuaTeX.\MessageBreak
-I will proceed with the compilation, but\MessageBreak
-the output is not guaranteed to be correct\MessageBreak
-and may look very wrong.}
-\fi
+
 % Translations provided by Anmol Sharma <unmole.in@gmail.com>
 
 \PolyglossiaSetup{telugu}{

--- a/tex/gloss-thai.ldf
+++ b/tex/gloss-thai.ldf
@@ -8,12 +8,6 @@
 %%%%              Thai Linux Working Group
 %%%%              http://linux.thai.net/
 %%%%
-\ifluatex
-  \xpg@warning{Thai is not supported with LuaTeX.\MessageBreak
-I will proceed with the compilation, but\MessageBreak
-the output is not guaranteed to be correct\MessageBreak
-and may look very wrong.}
-\fi
 \PolyglossiaSetup{thai}{
   bcp47=th,
   script=Thai,

--- a/tex/gloss-urdu.ldf
+++ b/tex/gloss-urdu.ldf
@@ -1,11 +1,6 @@
 %%% Adapted from a file contributed by Kamal Abdali
 \ProvidesFile{gloss-urdu.ldf}[polyglossia: module for Urdu]
-\ifluatex
-  \xpg@warning{Urdu is not supported with LuaTeX.\MessageBreak
-I will proceed with the compilation, but\MessageBreak
-the output is not guaranteed to be correct\MessageBreak
-and may look very wrong.}
-\fi
+
 \RequireBidi
 \RequirePackage{arabicnumbers}
 \RequirePackage{hijrical}

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -2178,18 +2178,34 @@
      .bool_set:N = \l_polyglossia_babelshorthands_bool,
   babelshorthands
      .default:n = true,
+
+  luatexrenderer
+     .cs_set:Np = \l_polyglossia_luatex_renderer,
+  luatexrenderer
+     .value_required:n = true,
 }
 
 \keys_set:nn { polyglossia } {
   localmarks = false,
   verbose = true,
   babelshorthands = false,
+  luatexrenderer = Harfbuzz
 }
 
 % load by default latex
 \setmainlanguage{latex}
 % then process key in order to overwrite
 \ProcessKeysOptions{polyglossia}
+
+% Set the LuaTeX renderer. As opposed to fontspec, we use Harfbuzz by default.
+% This can be changed via the luatexrenderer package option.
+\ifluatex
+  \exp_args:Nee \str_if_eq:nnF{\l_polyglossia_luatex_renderer}{none}
+     {
+         \xpg@info{Setting~ LuaTeX~ font~ renderer~ to~ \l_polyglossia_luatex_renderer}
+         \exp_args:Nee \defaultfontfeatures{Renderer=\l_polyglossia_luatex_renderer}
+     }
+\fi
 
 \bool_if:nTF \l_polyglossia_verbose_bool {} {
    \gdef\@latex@info#1{\relax}% no latex info


### PR DESCRIPTION
This also introduces the package option `luatexrenderer` which allows to
change this default.

This should address the LuaTeX output deficiencies with some scripts
(https://github.com/reutenauer/polyglossia/issues/337)