### PR TITLE
Fix problem with large character indices

### DIFF
--- a/doc/Changelog
+++ b/doc/Changelog
@@ -40,6 +40,8 @@ Bug fixes:
     and introduce option forceheadingpunctuation (#444).
   * Fix Cyrillic dash (via babelshorthand "---) when TeX ligatures
     are disabled (#445)
+  * Fix problem with great character indices in Lua module for punctuation
+    spacing
 
 Interface and defaults changes:
 

--- a/tex/polyglossia-punct.lua
+++ b/tex/polyglossia-punct.lua
@@ -93,21 +93,21 @@ local left_bracket_chars = {
 
 -- all right bracket characters, referenced by their Unicode slot
 local right_bracket_chars = {
-    [0x29] = true, -- right parenthesis
-    [0x5D] = true, -- right square bracket
-    [0x7D] = true, -- right curly bracket
+    [0x29] = true,  -- right parenthesis
+    [0x5D] = true,  -- right square bracket
+    [0x7D] = true,  -- right curly bracket
     [0x27E9] = true -- mathematical right angle bracket
 }
 
 -- question and exclamation marks, referenced by their Unicode slot
 local question_exclamation_chars = {
-    [0x21] = true, -- exclamation mark !
-    [0x3F] = true, -- question mark ?
+    [0x21] = true,   -- exclamation mark !
+    [0x3F] = true,   -- question mark ?
     [0x203C] = true, -- double exclamation mark ‼
     [0x203D] = true, -- interrobang ‽
     [0x2047] = true, -- double question mark ⁇
     [0x2048] = true, -- question exclamation mark ⁈
-    [0x2049] = true, -- exclamation question mark ⁉
+    [0x2049] = true  -- exclamation question mark ⁉
 }
 
 -- from nodes-tst.lua, adapted
@@ -233,9 +233,12 @@ local function process(head)
         if id == glyph_code then
             local attr = has_attribute(current, punct_attr)
             if attr then
-                local char = utf8.char(current.char) -- requires Lua 5.3
-                local leftspace  = left_space[attr][char]
-                local rightspace = right_space[attr][char]
+                local char, leftspace, rightspace
+                if current.char <= 0x10FFFF then -- greater values may cause problems with utf8.char
+                    char = utf8.char(current.char)
+                    leftspace  = left_space[attr][char]
+                    rightspace = right_space[attr][char]
+                end
                 if leftspace or rightspace then
                     local fontparameters = fonts.hashes.parameters[current.font]
                     local unit, stretch, shrink, spacing_node


### PR DESCRIPTION
Harfbuzz sometimes uses very large character indices for glyph nodes. The Lua command `utf8.char` is not able to convert these indices to characters. This commit prevents an error message in these cases.