### PR TITLE
Serbian: Verify indentfirst

### DIFF
--- a/tex/gloss-serbian.ldf
+++ b/tex/gloss-serbian.ldf
@@ -11,7 +11,7 @@
   langtag=SRB,
   hyphennames={serbian},
   hyphenmins={2,2},
-  indentfirst=true,
+  indentfirst=true, % Правопис српскога језика, Матица српска, 1994. (друго издање): т. 236, под Обликовање ступца и пасуса
   fontsetup=false,
   localnumeral=serbiannumerals,
   Localnumeral=Serbiannumerals,


### PR DESCRIPTION
Правопис српскога језика, Матица српска, 1994. (друго издање)
т. 236, под Обликовање ступца и пасуса

Исто тако је норма – и у штампарству и у сваком писању – да се на почетку пасуса ред обавезно увлачи (осим кад пасус почиње крупним иницијалом). У машинском писању ред се нормално увлачи за пет словних места, а у књигама око четири типична словна места, с тим што је увлачење упола мање ако је слог двостубачан. Није рационалан – па тиме остаје и изван норме – помодни манир да се почетни ред пасуса не увлачи, с тим што се прелазак на други пасус сигнализује повећаним проредом (белином). Белина између пасуса не треба да се примењује механички него осмишљено, да се по потреби истакне граница садржајних целина састављених од више пасуса. Пасус без увлачења првог реда посебно је непогодан на почетку странице, јер се тада не види је ли она започета новим пасусом или се наставља већ започети.

Текст је написао Митар Пешикан, који се, осим србистиком, бавио и проблемима типографије, па се његов став не мора доводити у питање.

...

Q: Да ли се само на почетку првог пасуса у тексту прави увлачење или се прави на почетку сваког пасуса?
A: На почетку сваког новог пасуса.

Google Translate (a bit improved):
It is also the norm – both in printing and in every writing – that the line must be indented at the beginning of the paragraph (except when it starts with a large initial). In typewriting, the line is normally indented by five letters, and in books by about four typical letters, with the indentation being half less if the layout is two-column. It is not rational – and thus remains out of the norm – a fashionable manner not to indent the initial line of the paragraph, with the fact that the transition to the second paragraph is signaled by increased spacing (whiteness). The whiteness between paragraphs should not be applied mechanically but deliberately, to emphasize, if necessary, the boundary of content units composed of several paragraphs. The paragraph without indenting the first line is especially inconvenient at the beginning of the page, because then it is not clear whether it has started with a new paragraph or continues already started.

The text was written by Mitar Pešikan, who, in addition to Serbian studies, also dealt with the problems of typography, so his judgment does not have to be questioned.

...

Q: Is an indentation made only at the beginning of the first paragraph of the text or is it made at the beginning of each paragraph?
A: At the beginning of each new paragraph.


References:
https://www.vokabular.org/forum/index.php?action=printpage;topic=2423.0
https://gimnazijadg.files.wordpress.com/2012/03/pravopis-srpskoga-jezika.pdf