### PR TITLE
Serbian: Explicit `frenchspacing=true`

### DIFF
--- a/tex/gloss-serbian.ldf
+++ b/tex/gloss-serbian.ldf
@@ -11,7 +11,8 @@
   langtag=SRB,
   hyphennames={serbian},
   hyphenmins={2,2},
-  indentfirst=true, % Правопис српскога језика, Матица српска, 1994. (друго издање): т. 236, под Обликовање ступца и пасуса
+  frenchspacing=true, % Правопис српскога језика, Матица српска, 2010. (измењено и допуњено, четврто издање): т. 188, под Обликовање ступца и пасуса
+  indentfirst=true, % Правопис српскога језика, Матица српска, 2010. (измењено и допуњено, четврто издање): т. 188, под Обликовање ступца и пасуса
   fontsetup=false,
   localnumeral=serbiannumerals,
   Localnumeral=Serbiannumerals,


### PR DESCRIPTION
Updated references for both `frenchspacing` and `indentfirst`: https://jelenaradomir.files.wordpress.com/2016/08/pravopis-ms_2010.pdf.

![image](https://user-images.githubusercontent.com/1058211/115991858-bf83e100-a5ca-11eb-9e2d-506c4bafae5c.png)

У штампарству се, дакле, редови морају потпуно уједначити по дужини, што се постиже подешавањем белина и прелома речи на крају реда. Једино последњи ред у пасусу не треба да иде до десне ивице, ако се то може на погодан начин избећи.

Google Translate (a bit improved):
In printing, therefore, the lines must be completely uniform in length, which is achieved by adjusting the whiteness and the word break at the end of the line. Only the last line in the paragraph should not go to the right edge if that can be avoided in a suitable way.

![image](https://user-images.githubusercontent.com/1058211/115991776-500df180-a5ca-11eb-87e9-bb441b0c46b3.png)
