### PR TITLE
WIP support standard transliteraion of Hebrew calendar months

### DIFF
--- a/tests/test-hebrew-calendar-alt-tl.tex
+++ b/tests/test-hebrew-calendar-alt-tl.tex
@@ -1,6 +1,6 @@
 \documentclass{minimal}
 
-\usepackage{hebrewcal}
+\usepackage[transliteration=alt]{hebrewcal}
 
 \begin{document}
 
@@ -8,7 +8,7 @@
 \month=4
 \year=2012
 
-% Should be Iyyar 6, 5772
+% Should be Iyar 6, 5772
 \hebrewtoday
 
 \day=17

--- a/tex/hebrewcal.sty
+++ b/tex/hebrewcal.sty
@@ -20,6 +20,19 @@
   \fi
 }
 
+\newif\if@xpg@hebrewcal@academytransliteration
+\@xpg@hebrewcal@academytransliteration
+
+\DeclareOption{academytransliteration}{\@xpg@hebrewcal@academytransliteration}
+
+
+\@ifundefined{if@xpg@hebrew@academytransliteration}{}{%
+  \if@xpg@hebrew@academytransliteration
+     \@xpg@hebrewcal@academytransliterationtrue
+  \fi
+}
+
+
 %% TODO rewrite this on the basis of Reingold & Dershowitz 
 %%      on the model of hijrical (using calc)
 
@@ -99,18 +112,21 @@
     \else%
         \ifcase #1%
             % nothing for 0
-            \or Tishrei%
-            \or\if@xpg@hebrewcal@marcheshvan Marcheshvan\else Heshvan\fi%
+            \or \if@xpg@hebrewcal@academytransliteration Tishri\else Tishrei\fi%
+            \or \if@xpg@hebrewcal@academytransliteration%
+              \if@xpg@hebrewcal@marcheshvan Marẖeshvan\else Heshvan\fi%
+              \else \if@xpg@hebrewcal@marcheshvan Marcheshvan\else Cheshvan\fi%
+            \fi%
             \or Kislev%
-            \or Tebeth%
-            \or Shebat%
+            \or \if@xpg@hebrewcal@academytransliteration Tevet\else Tebeth\fi%
+            \or \if@xpg@hebrewcal@academytransliteration Shvat\else Shebat\fi%
             \or Adar I%
             \or Adar II%
             \or Nisan%
-            \or Iyar%
+            \or \if@xpg@hebrewcal@academytransliteration Iyyar\else Iyar\fi%
             \or Sivan%
             \or Tammuz%
-            \or Av%
+            \or \if@xpg@hebrewcal@academytransliteration Av\else Ab\fi%
             \or Elul%
         \fi
     \fi}
@@ -221,12 +237,12 @@
                0 \or%          % Tishri
               30 \or%          % Heshvan
               59 \or%          % Kislev
-              89 \or%          % Tebeth
-             118 \or%          % Shebat
+              89 \or%          % Tevet
+             118 \or%          % Shvat
              148 \or%          % Adar I
              148 \or%          % Adar II
              177 \or%          % Nisan
-             207 \or%          % Iyar
+             207 \or%          % Iyyar
              236 \or%          % Sivan
              266 \or%          % Tammuz
              295 \or%          % Av

--- a/tex/hebrewcal.sty
+++ b/tex/hebrewcal.sty
@@ -1,5 +1,5 @@
 \ProvidesPackage{hebrewcal}
-        [2019/12/03 v2.7 %
+        [2022/07/16 v2.8 %
          Hebrew calendar for polyglossia (adapted from hebcal.sty in Babel)]
 \RequirePackage{xkeyval}
 \RequirePackage{iftex}
@@ -13,6 +13,8 @@
 \@xpg@hebrewcal@marcheshvanfalse
 
 \DeclareOption{marcheshvan}{\@xpg@hebrewcal@marcheshvantrue}
+\DeclareOptionX{style}{%
+  \def\my@emphstyle{\csname my@style@#1\endcsname}}
 
 \@ifundefined{if@xpg@hebrew@marcheshvan}{}{%
   \if@xpg@hebrew@marcheshvan
@@ -26,8 +28,18 @@
 \@ifundefined{@Remainder}{\input{cal-util.def}}{}
 
 \define@boolkey{hebrew}[@hebrew@]{fullyear}[true]{}
-\define@boolkey{hebrew}[@hebrew@]{academytransliteration}[true]{}
-\setkeys{hebrew}{fullyear=false,academytransliteration=true}
+
+%\PackageWarning{foo}{bar}
+
+\define@choicekey*+{hebrew}{transliteration}[\xpg@hebrew@tlval\xpg@hebrew@tlnr]{academy,alt}[alt]{%
+\message{Processing transliteration; got \xpg@hebrew@tlval (index \xpg@hebrew@tlnr), and that's it.}%
+}{\PackageWarning{hebcal}{Unknown transliteration option `#1'}}%
+
+\setkeys{hebrew}{fullyear=false,transliteration=alt}
+    % Note: For some reason, without this explicit setting, the transliteration macros are not set
+    % using the default vaue provided to \define@choicekey . SO, we must be more "forceful" and set
+    % the key explicitly.
+
 
 \newcount\hebrewday  \newcount\hebrewmonth \newcount\hebrewyear
 \def\hebrewdate#1#2#3{%
@@ -100,21 +112,21 @@
     \else%
         \ifcase #1%
             % nothing for 0
-            \or \if@hebrew@academytransliteration Tishri\else Tishrei\fi%
-            \or \if@hebrew@academytransliteration%
+            \or \ifcase\xpg@hebrew@tlnr\relax Tishri \or Tishrei \fi%
+            \or \ifcase\xpg@hebrew@tlnr\relax%
               \if@xpg@hebrewcal@marcheshvan Marẖeshvan\else Heshvan\fi%
               \else \if@xpg@hebrewcal@marcheshvan Marcheshvan\else Cheshvan\fi%
             \fi%
             \or Kislev%
-            \or \if@hebrew@academytransliteration Tevet\else Tebeth\fi%
-            \or \if@hebrew@academytransliteration Shvat\else Shebat\fi%
+            \or \ifcase\xpg@hebrew@tlnr\relax Tevet \or Tebeth \fi%
+            \or \ifcase\xpg@hebrew@tlnr\relax Shvat \or Shebat \fi%
             \or Adar I%
             \or Adar II%
             \or Nisan%
-            \or \if@hebrew@academytransliteration Iyyar\else Iyar\fi%
+            \or \ifcase\xpg@hebrew@tlnr\relax Iyyar \or Iyar \fi%
             \or Sivan%
             \or Tammuz%
-            \or \if@hebrew@academytransliteration Av\else Ab\fi%
+            \or \ifcase\xpg@hebrew@tlnr\relax Av \or Ab \fi%
             \or Elul%
         \fi
     \fi}
@@ -353,5 +365,5 @@
         \repeat%
         \global\advance #5 by -1%
         \global\advance #4 by -\tmpy}}
-\ProcessOptions*
+\ProcessOptionsX*<hebrew>
 \endinput

--- a/tex/hebrewcal.sty
+++ b/tex/hebrewcal.sty
@@ -20,26 +20,14 @@
   \fi
 }
 
-\newif\if@xpg@hebrewcal@academytransliteration
-\@xpg@hebrewcal@academytransliteration
-
-\DeclareOption{academytransliteration}{\@xpg@hebrewcal@academytransliteration}
-
-
-\@ifundefined{if@xpg@hebrew@academytransliteration}{}{%
-  \if@xpg@hebrew@academytransliteration
-     \@xpg@hebrewcal@academytransliterationtrue
-  \fi
-}
-
-
 %% TODO rewrite this on the basis of Reingold & Dershowitz 
 %%      on the model of hijrical (using calc)
 
 \@ifundefined{@Remainder}{\input{cal-util.def}}{}
 
 \define@boolkey{hebrew}[@hebrew@]{fullyear}[true]{}
-\setkeys{hebrew}{fullyear=false}
+\define@boolkey{hebrew}[@hebrew@]{academytransliteration}[true]{}
+\setkeys{hebrew}{fullyear=false,academytransliteration=true}
 
 \newcount\hebrewday  \newcount\hebrewmonth \newcount\hebrewyear
 \def\hebrewdate#1#2#3{%
@@ -112,21 +100,21 @@
     \else%
         \ifcase #1%
             % nothing for 0
-            \or \if@xpg@hebrewcal@academytransliteration Tishri\else Tishrei\fi%
-            \or \if@xpg@hebrewcal@academytransliteration%
+            \or \if@hebrew@academytransliteration Tishri\else Tishrei\fi%
+            \or \if@hebrew@academytransliteration%
               \if@xpg@hebrewcal@marcheshvan Marẖeshvan\else Heshvan\fi%
               \else \if@xpg@hebrewcal@marcheshvan Marcheshvan\else Cheshvan\fi%
             \fi%
             \or Kislev%
-            \or \if@xpg@hebrewcal@academytransliteration Tevet\else Tebeth\fi%
-            \or \if@xpg@hebrewcal@academytransliteration Shvat\else Shebat\fi%
+            \or \if@hebrew@academytransliteration Tevet\else Tebeth\fi%
+            \or \if@hebrew@academytransliteration Shvat\else Shebat\fi%
             \or Adar I%
             \or Adar II%
             \or Nisan%
-            \or \if@xpg@hebrewcal@academytransliteration Iyyar\else Iyar\fi%
+            \or \if@hebrew@academytransliteration Iyyar\else Iyar\fi%
             \or Sivan%
             \or Tammuz%
-            \or \if@xpg@hebrewcal@academytransliteration Av\else Ab\fi%
+            \or \if@hebrew@academytransliteration Av\else Ab\fi%
             \or Elul%
         \fi
     \fi}


### PR DESCRIPTION
This adds a `hebrewcal.sty` package option to use the Hebrew Language Academy transliteration for English month names.

Resolves #540.

This is a WIP and untested PR for review purposes.