### PR TITLE
Fix `otherlanguage*` environment

### DIFF
--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -1867,7 +1867,7 @@
 {%
   \__xpg_otherlanguage:eee {#1} {#2} {\xpg_alias_base_lang:n{#2}}
 }
-{\group_end:}
+{\egroup}
 
 % internal wrapper
 % #1 option
@@ -1880,7 +1880,7 @@
     \msg_show:nnn { polyglossia } { languagenotloaded } {#2}
   }
   \xpg@otherlanguage[\xpg_alias_add_to_option_i:nn{#2}{#1}]{#3}%
-  \polyglossia@lang@settextdirection:nn{#3}\group_begin:%
+  \polyglossia@lang@settextdirection:nn{#3}\bgroup
 }
 \cs_generate_variant:Nn \__xpg_otherlanguage:nnn {
   eee


### PR DESCRIPTION
Currently trying to use the `otherlanguage*` environment results in the following error:
```
! Extra }, or forgotten \endgroup.
<argument> ...ettextdirection:n {\l_tmpa_tl }{\group_begin: }
```
This is caused by the fact that when choosing a text direction via `\LRE` or `\RLE` it expects the argument to be delimited by `{` and `}`. Change made in 5a4ab9e9eb07d3e58bdcd519b0cb0c9f55e74b01 made it so that it is now delimited by `\begingroup` and `\endgroup` which doesn't work. This PR reverts it back to `\bgroup` and `\egroup` which are just commands that expand to `{` and `}` respectively.