### PR TITLE
Re-fix Hungarian patching of parts with hyperref (#555)

### DIFF
--- a/tex/gloss-hungarian.ldf
+++ b/tex/gloss-hungarian.ldf
@@ -133,9 +133,9 @@
   \if@hungarian@swapheadings
      % With titlesec
      \ifcsdef{titleformat}{%
-       \ifcsdef{H@old@part}{% Hyperref
-            \let\xpg@save@part@format\H@old@part%
-            \patchcmd{\H@old@part}%
+       \ifcsdef{NR@part}{% Hyperref
+            \let\xpg@save@part@format\NR@part%
+            \patchcmd{\NR@part}%
                       {\partname\nobreakspace\thepart}%
                       {\thepart.\nobreakspace\partname}%
                       {}%
@@ -177,9 +177,9 @@
                        {}%
                        {\xpg@warning{Failed to patch chapter for Hungarian}}%
            }{}%
-           \ifcsdef{H@old@part}{% Hyperref
-                \let\xpg@save@part@format\H@old@part%
-                \patchcmd{\H@old@part}{\printpartname \partnamenum \printpartnum}%
+           \ifcsdef{NR@part}{% Hyperref
+                \let\xpg@save@part@format\NR@part%
+                \patchcmd{\NR@part}{\printpartname \partnamenum \printpartnum}%
                                  {\printpartnum.\partnamenum\printpartname}%
                                  {}%
                                  {\xpg@warning{Failed to patch part for Hungarian}}%
@@ -202,9 +202,9 @@
                        {}%
                        {\xpg@warning{Failed to patch chapter for Hungarian}}%
             }{}%
-            \ifcsdef{H@old@part}{% Hyperref
-              \let\xpg@save@part@format\H@old@part%
-              \patchcmd{\H@old@part}%
+            \ifcsdef{NR@part}{% Hyperref
+              \let\xpg@save@part@format\NR@part%
+              \patchcmd{\NR@part}%
                        {\partname\nobreakspace\thepart}%
                        {\thepart.\nobreakspace\partname}%
                        {}%
@@ -271,8 +271,8 @@
    \ifcsdef{titleformat}{%
       % With titlesec
      \ifcsdef{xpg@save@part@format}{%
-        \ifcsdef{H@old@part}{%
-            \let\H@old@part\xpg@save@part@format%
+        \ifcsdef{NR@part}{%
+            \let\NR@part\xpg@save@part@format%
         }{%
             \let\@part\xpg@save@part@format%
         }%
@@ -294,8 +294,8 @@
      }{%
         % With memoir and standard classes
         \ifcsdef{xpg@save@part@format}{%
-           \ifcsdef{H@old@part}{%
-               \let\H@old@part\xpg@save@part@format%
+           \ifcsdef{NR@part}{%
+               \let\NR@part\xpg@save@part@format%
            }{%
                \let\@part\xpg@save@part@format%
            }%


### PR DESCRIPTION
The solution is based on (#546). Hyperref now loads nameref, so we must
patch deeper.