### PR TITLE
Further development of (#557) and documentation

### DIFF
--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -1302,6 +1302,13 @@ and that passing \xpgvalue{babelshorthands} (without value) is equivalent to pas
 	       	\item ¦hheaders¦: Redefine part and chapter headings as well as running headers
 	       	\item ¦none¦: Do not redefine anything
 	       \end{itemize}
+    \item \xpgboolkeytrue[1.58]{forceheadingpunctuation}
+        Section numbers always have a trailing punctuation in Hungarian (as in \emph{1.1.} as opposed to \emph{1.1}).
+        For compatibility reasons, the default option is \xpgvalue{false}, thus \textsf{polyglossia}
+        does not touch heading punctuation, so this will be whatever the class or a package determines.
+        Set this option to \xpgvalue{true}, 
+        and \textsf{polyglossia} appends a period after the section counters, 
+        and adjusts the header punctuation (as in \emph{1. fejezet.} as opposed to \emph{1. fejezet}).
 \end{itemize}
 \paragraph*{Commands:}
 \begin{itemize}
@@ -2433,6 +2440,8 @@ where \meta{type} is a supported language id type (such as ¦bcp-47¦) and \meta
 
 \subsubsection*{Bug fixes}
 \begin{itemize}
+    \item The option \xpgoption{forceheadingpunctuation} is introduced
+        for correct running headers in Hungarian documents (\TXI{557}).
 	\item Fix language setting in list of figure and table if captions float to different
 	      language areas (\TXI{542}).
 	\item Make Croatian digraphs robust (\TXI{552}).

--- a/tex/gloss-hungarian.ldf
+++ b/tex/gloss-hungarian.ldf
@@ -61,8 +61,8 @@
 % Register default options
 % forceheadinpunctuatin is recommended, but the default value is false for compatibility reasons
 \xpg@initialize@gloss@options{hungarian}{swapstrings=all,
-                                         forceheadingpunctuation=false
-                                        }
+                                         forceheadingpunctuation=false}
+
 
 \def\hungarian@language{%
    \polyglossia@setup@language@patterns{hungarian}%
@@ -333,7 +333,7 @@
 \ifdef{\KOMAScript}{%
     \providecommand*\autodot{}%
     \let\xpg@save@autodot\autodot%
-}
+}{}
 % The following is based on some ideas from gloss-russian.ldf
 \def\hungarian@sectsformat{%
   \ifhungarian@forceheadingpunctuation%

--- a/tex/gloss-hungarian.ldf
+++ b/tex/gloss-hungarian.ldf
@@ -55,8 +55,14 @@
    \xpg@info{Option: Hungarian, swapstrings=\xpg@val}%
 }{\xpg@warning{Unknown Hungarian swapstrings value `#1'}}
 
+% Force punctuation: 1) after section type counters; 2) after @chapapp in the running head
+\define@boolkey{hungarian}[hungarian@]{forceheadingpunctuation}[true]{}
+
 % Register default options
-\xpg@initialize@gloss@options{hungarian}{swapstrings=all}
+% forceheadinpunctuatin is recommended, but the default value is false for compatibility reasons
+\xpg@initialize@gloss@options{hungarian}{swapstrings=all,
+                                         forceheadingpunctuation=false
+                                        }
 
 \def\hungarian@language{%
    \polyglossia@setup@language@patterns{hungarian}%
@@ -133,7 +139,7 @@
   \if@hungarian@swapheadings
      % With titlesec
      \ifcsdef{titleformat}{%
-       \ifcsdef{NR@part}{% Hyperref
+       \ifcsdef{NR@part}{% Hyperref (nameref)
             \let\xpg@save@part@format\NR@part%
             \patchcmd{\NR@part}%
                       {\partname\nobreakspace\thepart}%
@@ -177,7 +183,7 @@
                        {}%
                        {\xpg@warning{Failed to patch chapter for Hungarian}}%
            }{}%
-           \ifcsdef{NR@part}{% Hyperref
+           \ifcsdef{NR@part}{% Hyperref (nameref)
                 \let\xpg@save@part@format\NR@part%
                 \patchcmd{\NR@part}{\printpartname \partnamenum \printpartnum}%
                                  {\printpartnum.\partnamenum\printpartname}%
@@ -202,13 +208,13 @@
                        {}%
                        {\xpg@warning{Failed to patch chapter for Hungarian}}%
             }{}%
-            \ifcsdef{NR@part}{% Hyperref
+            \ifcsdef{NR@part}{% Hyperref (nameref)
               \let\xpg@save@part@format\NR@part%
               \patchcmd{\NR@part}%
                        {\partname\nobreakspace\thepart}%
                        {\thepart.\nobreakspace\partname}%
                        {}%
-                       {\xpg@warning{Failed to patch part for Hungarian}}%            
+                       {\xpg@warning{Failed to patch part for Hungarian}}%
             }{% not hyperref
               \ifcsdef{@part}{%
                 \let\xpg@save@part@format\@part%
@@ -230,7 +236,7 @@
       % With KOMA
       \let\xpg@save@chaptermark@format\chaptermarkformat%
       \renewcommand*\chaptermarkformat{%
-         \thechapter\autodot\ \IfChapterUsesPrefixLine{\chapapp.\enskip}{}}
+         \thechapter\autodot\ \IfChapterUsesPrefixLine{\chapapp\@hungarian@forced@dot\enskip}{}}
     }{% (not \ifdefined\chapterformat)
       \ifcsdef{@memptsize}{%
         % With memoir
@@ -239,7 +245,7 @@
           \markboth{\memUChead{%
             \ifnum \c@secnumdepth >\m@ne
               \ifbool{@mainmatter}{%
-                \thechapter.\ \@chapapp.\ %
+                \thechapter.\ \@chapapp\@hungarian@forced@dot\ %
               }{}%
             \fi
             ##1}}{}}%
@@ -251,7 +257,7 @@
                {\let\xpg@save@chaptermark@format\chaptermark%
                 \patchcmd{\chaptermark}%
                     {\@chapapp\ \thechapter.}%
-                    {\thechapter.\ \@chapapp.}%
+                    {\thechapter.\ \@chapapp\@hungarian@forced@dot}%
                     {}%
                     {\xpg@warning{Failed to patch chaptermark for Hungarian}}}%
                {}%
@@ -321,14 +327,60 @@
      }{}% (end \ifdefined\chaptermark)
   }% (end \ifdefined\chapterformat)
 }
-
+% Hungarian needs 1) trailing dots in chapter headings; 2) trailing dot in section, subsection, etc, counters
+\def\@hungarian@forced@dot{}
+\def\xpg@save@autodot{}
+\ifdef{\KOMAScript}{%
+    \providecommand*\autodot{}%
+    \let\xpg@save@autodot\autodot%
+}
+% The following is based on some ideas from gloss-russian.ldf
+\def\hungarian@sectsformat{%
+  \ifhungarian@forceheadingpunctuation%
+   \ifdef{\KOMAScript}{%
+      \renewcommand*\autodot{.}%
+   }{%
+      \def\@seccntformat##1{\csname pre##1\endcsname%
+         \csname the##1\endcsname%
+         \csname post##1\endcsname}%
+       \def\@aftersepkern{\hspace{0.5em}}%
+       \def\postchapter{.\@aftersepkern}%
+       \def\postsection{.\@aftersepkern}%
+       \def\postsubsection{.\@aftersepkern}%
+       \def\postsubsubsection{.\@aftersepkern}%
+       \def\postparagraph{.\@aftersepkern}%
+       \def\postsubparagraph{.\@aftersepkern}%
+       \def\prechapter{}%
+       \def\presection{}%
+       \def\presubsection{}%
+       \def\presubsubsection{}%
+       \def\preparagraph{}%
+       \def\presubparagraph{}%
+    }%
+   \def\@hungarian@forced@dot{.}
+  \fi%
+}
+%
+\def\nohungarian@sectsformat{%
+  \ifhungarian@forceheadingpunctuation%
+    \ifdef{\KOMAScript}{%
+       \let\autodot\xpg@save@autodot%
+    }{%
+       \def\@seccntformat##1{\csname the##1\endcsname\quad}% = LaTeX kernel
+    }%
+  \fi%
+  \def\@hungarian@forced@dot{}
+}
+%
 \def\blockextras@hungarian{%
    \hungarian@capsformat%
+   \hungarian@sectsformat%
 }
-
+%
 \def\noextras@hungarian{%
    \nohungarian@capsformat%
+   \nohungarian@sectsformat%
    \let\ontoday\@undefined%
 }
-
+%
 \endinput


### PR DESCRIPTION
As we discussed finally in (https://github.com/reutenauer/polyglossia/issues/557) new option `forceheadingpunctuation` is introduced. It is false by default for compatibility reasons. The option covers the punctuation to running headers and, at the same time, the section counters.
Thus the recommended call is `\setdefaultlanguage[forcedheadingpunctuation]{hungarian}`, for example.
Tested successfully under `memoir`, classic `book` and KOMA's `scrbook`.
At the earlier pull request (#560) was closed by myself, because the test under KOMA revealed a mistake in the code.
The documentation is also adjusted.
