### PR TITLE
making Hebrew numerals expandable

### DIFF
--- a/tex/babel-hebrewalph.def
+++ b/tex/babel-hebrewalph.def
@@ -77,6 +77,6 @@
 }
 
 \newcommand*\Alphfinal[1]{\expandafter\@Alphfinal\csname c@#1\endcsname}
-\providecommand*{\@Alphfinal}[1]{\Hebrewnumeralfinal{#1}}
+\newcommand*\@Alphfinal[1]{\Hebrewnumeralfinal{#1}}
 
 \endinput

--- a/tex/babel-hebrewalph.def
+++ b/tex/babel-hebrewalph.def
@@ -1,9 +1,7 @@
 \ProvidesFile{babel-hebrewalph.def}
-         [2010/03/02 %
-         Babel definitions for Hebrew numerals^^J
-         Adapted from hebrew.ldf (2005/03/30 v2.3h)]
-\newif\if@gim@apost  % whether we print apostrophes (gereshayim)
-\newif\if@gim@final  % whether we use final or initial letters
+         [2023/06/01 %
+         Expandable definitions for Hebrew numerals]
+
 \newcommand*\hebrewnumeral[1]{%
   \expandafter\@hebrew@numeral\expandafter{\the\numexpr#1}%
 }
@@ -13,76 +11,69 @@
 \newcommand*\Hebrewnumeralfinal[1]{%
   \expandafter\@Hebrew@numeralfinal\expandafter{\the\numexpr#1}%
 }
-\newrobustcmd*{\@hebrew@numeral}[1]      % no apostrophe, no final letters
- {{\@gim@finalfalse\@gim@apostfalse\@hebrew@@numeral{#1}}}
-\newrobustcmd*{\@Hebrew@numeral}[1]      % apostrophe, no final letters
- {{\@gim@finalfalse\@gim@aposttrue\@hebrew@@numeral{#1}}}
-\newrobustcmd*{\@Hebrew@numeralfinal}[1] % apostrophe, final letters
- {{\@gim@finaltrue\@gim@aposttrue\@hebrew@@numeral{#1}}}
-\newcommand*{\@hebrew@@numeral}[1]{%
+
+\newcommand*\hebrew@div@trancate[2]{%
+	\ifnum\numexpr #1 - #2*\numexpr #1/#2\relax<0
+	\the\numexpr #1/#2 -1\relax\else\the\numexpr #1/#2\relax\fi
+}
+ 
+\newcommand*\@hebrew@@numeral[2]{%
   \ifnum#1<\z@\space\xpg@warning{Illegal value (#1) for Hebrew numeral}%
   \else
-    \@tempcnta=#1\@tempcntb=#1\relax
-    \divide\@tempcntb by 1000
-    \ifnum\@tempcntb=0\gim@nomil\@tempcnta\relax
-    \else{\@gim@apostfalse\@gim@finalfalse\@hebrew@numeral\@tempcntb}׳%
-          \multiply\@tempcntb by 1000\relax
-          \advance\@tempcnta by -\@tempcntb\relax
-          \gim@nomil\@tempcnta\relax
+    \ifnum #1<1000
+		\gim@nomil{#1}{#2}%
+    \else
+		\hebrewnumeral{\hebrew@div@trancate{#1}{1000}}׳%
+        \expandafter\gim@nomil\expandafter{\the\numexpr #1 - 1000*\hebrew@div@trancate{#1}{1000}}{#2}%
     \fi
   \fi
 }
-\def\hebrew@alph@zero{}
-\newcommand*{\gim@nomil}[1]{\@tempcnta=#1\@gim@prevfalse
-  \@tempcntb=\@tempcnta\divide\@tempcntb by 100\relax % hundreds digit
-  \ifcase\@tempcntb                     % print nothing if no hundreds
-     \or\gim@print{100}{ק}%
-     \or\gim@print{200}{ר}%
-     \or\gim@print{300}{ש}%
-     \or\gim@print{400}{ת}%
-     \or ת\@gim@prevtrue\gim@print{500}{ק}%
-     \or ת\@gim@prevtrue\gim@print{600}{ר}%
-     \or ת\@gim@prevtrue\gim@print{700}{ש}%
-     \or ת\@gim@prevtrue\gim@print{800}{ת}%
-     \or ת\@gim@prevtrue ת\gim@print{900}{ק}%
+
+\newcommand*\@hebrew@numeral[1]{\@hebrew@@numeral{#1}{0}}
+\newcommand*\@Hebrew@numeral[1]{\@hebrew@@numeral{#1}{1}}
+\newcommand*\@Hebrew@numeralfinal[1]{\@hebrew@@numeral{#1}{2}}
+
+\newcommand*\hebrew@alph@zero{}
+\newcommand*\gim@nomil[2]{%
+  \ifcase\hebrew@div@trancate{#1}{100}  % print nothing if no hundreds
+     \or ק\ifnum #2>0\ifnum #1=100 ׳\fi\fi
+     \or ר\ifnum #2>0\ifnum #1=200 ׳\fi\fi
+     \or ש\ifnum #2>0\ifnum #1=300 ׳\fi\fi
+     \or ת\ifnum #2>0\ifnum #1=400 ׳\fi\fi
+     \or ת\ifnum #2>0\ifnum #1=500 ״\fi\fi ק%
+     \or ת\ifnum #2>0\ifnum #1=600 ״\fi\fi ר%
+     \or ת\ifnum #2>0\ifnum #1=700 ״\fi\fi ש%
+     \or ת\ifnum #2>0\ifnum #1=800 ״\fi\fi ת%
+     \or תת\ifnum #2>0\ifnum #1=900 ״\fi\fi ק%
   \fi
-  \@tempcntb=\@tempcnta\divide\@tempcntb by 10\relax      % tens digit
-  \ifcase\@tempcntb                         % print nothing if no tens
-      \or                                   % number between 10 and 19
-              \ifnum\@tempcnta = 16 \gim@print {9}{ט}% tet-zayin
-         \else\ifnum\@tempcnta = 15 \gim@print {9}{ט}% tet-vav
-         \else                      \gim@print{10}{י}%
-              \fi % \@tempcnta = 15
-              \fi % \@tempcnta = 16
-      \or\gim@print{20}{\if@gim@final ך\else כ\fi}%
-      \or\gim@print{30}{ל}%
-      \or\gim@print{40}{\if@gim@final ם\else מ\fi}%
-      \or\gim@print{50}{\if@gim@final ן\else נ\fi}%
-      \or\gim@print{60}{ס}%
-      \or\gim@print{70}{ע}%
-      \or\gim@print{80}{\if@gim@final ף\else פ\fi}%
-      \or\gim@print{90}{\if@gim@final ץ\else צ\fi}%
+  \ifnum \the\numexpr #1 - 100*\hebrew@div@trancate{#1}{100} = 16
+  \ifnum #2>0 ט״ז\else טז\fi% tet-zayin
+  \else\ifnum \the\numexpr #1 - 100*\hebrew@div@trancate{#1}{100} = 15
+  \ifnum #2>0  ט״ו\else טו\fi% tet-vav
+  \else
+  \ifcase\expandafter\hebrew@div@trancate\expandafter{\the\numexpr #1 - 100*\hebrew@div@trancate{#1}{100}}{10}  % print nothing if no tens
+      \or \ifnum \the\numexpr #1 - 10*\hebrew@div@trancate{#1}{10}>0 י\else\ifnum #2>0\ifnum #1=10 י׳\else ״י\fi\else י\fi\fi
+      \or \ifnum \the\numexpr #1 - 10*\hebrew@div@trancate{#1}{10}>0 כ\else\ifnum #2>0\ifnum #1>20 ״\fi\fi\if #22ך\else כ\fi\ifnum #2>0\ifnum #1=20 ׳\fi\fi\fi
+      \or \ifnum \the\numexpr #1 - 10*\hebrew@div@trancate{#1}{10}>0 ל\else\ifnum #2>0\ifnum #1=30 ל׳\else ״ל\fi\else ל\fi\fi
+      \or \ifnum \the\numexpr #1 - 10*\hebrew@div@trancate{#1}{10}>0 מ\else\ifnum #2>0\ifnum #1>40 ״\fi\fi\if #22ם\else מ\fi\ifnum #2>0\ifnum #1=40 ׳\fi\fi\fi
+      \or \ifnum \the\numexpr #1 - 10*\hebrew@div@trancate{#1}{10}>0 נ\else\ifnum #2>0\ifnum #1>50 ״\fi\fi\if #22ן\else נ\fi\ifnum #2>0\ifnum #1=50 ׳\fi\fi\fi
+      \or \ifnum \the\numexpr #1 - 10*\hebrew@div@trancate{#1}{10}>0 ס\else\ifnum #2>0\ifnum #1=60 ס׳\else ״ס\fi\else ס\fi\fi
+      \or \ifnum \the\numexpr #1 - 10*\hebrew@div@trancate{#1}{10}>0 ע\else\ifnum #2>0\ifnum #1=70 ע׳\else ״ע\fi\else ע\fi\fi
+      \or \ifnum \the\numexpr #1 - 10*\hebrew@div@trancate{#1}{10}>0 פ\else\ifnum #2>0\ifnum #1>80 ״\fi\fi\if #22ף\else פ\fi\ifnum #2>0\ifnum #1=80 ׳\fi\fi\fi
+      \or \ifnum \the\numexpr #1 - 10*\hebrew@div@trancate{#1}{10}>0 צ\else\ifnum #2>0\ifnum #1>90 ״\fi\fi\if #22ץ\else צ\fi\ifnum #2>0\ifnum #1=90 ׳\fi\fi\fi
   \fi
-  \ifcase\@tempcnta
-      \hebrew@alph@zero%  empty but can be defined if desired
-      \or\gim@print{1}{א}%
-      \or\gim@print{2}{ב}%
-      \or\gim@print{3}{ג}%
-      \or\gim@print{4}{ד}%
-      \or\gim@print{5}{ה}%
-      \or\gim@print{6}{ו}%
-      \or\gim@print{7}{ז}%
-      \or\gim@print{8}{ח}%
-      \or\gim@print{9}{ט}%
-  \fi
+  \ifcase\the\numexpr #1 - 10*\hebrew@div@trancate{#1}{10}
+      \hebrew@alph@zero %  empty but can be defined if desired
+      \or \ifnum #2>0\ifnum #1=1 א׳\else ״א\fi\else א\fi
+      \or \ifnum #2>0\ifnum #1=2 ב׳\else ״ב\fi\else ב\fi
+      \or \ifnum #2>0\ifnum #1=3 ג׳\else ״ג\fi\else ג\fi
+      \or \ifnum #2>0\ifnum #1=4 ד׳\else ״ד\fi\else ד\fi
+      \or \ifnum #2>0\ifnum #1=5 ה׳\else ״ה\fi\else ה\fi
+      \or \ifnum #2>0\ifnum #1=6 ו׳\else ״ו\fi\else ו\fi
+      \or \ifnum #2>0\ifnum #1=7 ז׳\else ״ז\fi\else ז\fi
+      \or \ifnum #2>0\ifnum #1=8 ח׳\else ״ח\fi\else ח\fi
+      \or \ifnum #2>0\ifnum #1=9 ט׳\else ״ט\fi\else ט\fi
+  \fi\fi\fi
 }
-\newif\if@gim@prev % flag if a previous letter has been typeset
-\newcommand*{\gim@print}[2]{%   #2 is a letter, #1 is its value.
-  \advance\@tempcnta by -#1\relax% deduct the value from the remainder
-  \ifnum\@tempcnta=0% if this is the last letter
-     \if@gim@prev\if@gim@apost ״\fi#2%
-     \else#2\if@gim@apost ׳\fi\fi%
-  \else{\@gim@finalfalse#2}\@gim@prevtrue\fi}
-\def\Alphfinal#1{\expandafter\@Alphfinal\csname c@#1\endcsname}%
-\providecommand*{\@Alphfinal}[1]{\Hebrewnumeralfinal{#1}}
+
 \endinput

--- a/tex/babel-hebrewalph.def
+++ b/tex/babel-hebrewalph.def
@@ -76,4 +76,7 @@
   \fi\fi\fi
 }
 
+\newcommand*\Alphfinal[1]{\expandafter\@Alphfinal\csname c@#1\endcsname}
+\providecommand*{\@Alphfinal}[1]{\Hebrewnumeralfinal{#1}}
+
 \endinput


### PR DESCRIPTION
polyglossia adapted the definitions of `\hebrewnumeral`, `\Hebrewnumeral` and `\Hebrewnumeralfinal` from the old .ldf files of babel, but these macros are not expandable. 

One problem that arise from that is wring bookmark numbering in the pdf outline. For example, with the following code I'm getting the warning ``Token not allowed in a PDF string (Unicode):(hyperref) removing `\@Hebrew@numeral'``, and the outline is rendered as `1 שלום` and not `א' שלום`

```TeX
\documentclass{book}

\usepackage{polyglossia}
\usepackage{hyperref}
\hypersetup{bookmarksnumbered}
\setmainlanguage{hebrew}

\newfontfamily\hebrewfont{David CLM}[Script=Hebrew]

\begin{document}
	\appendix
	\chapter{שלום}
\end{document}
``` 

I compared the output PDFs of the following file (with various maximum number) with the old version and the one provided and it gives the same result (unless I missed something...)

```TeX
\documentclass{book}

\usepackage{polyglossia}
\setmainlanguage{hebrew}
\newfontfamily\hebrewfont{David CLM}[Script=Hebrew]

\begin{document}
	
\def\foo#1#2{%
	\hebrewnumeral{#1},
	\Hebrewnumeral{#1},
	\Hebrewnumeralfinal{#1},
	\ifnum#1<#2
	\expandafter\foo
	\expandafter{\number\numexpr#1+1\expandafter}%
	\expandafter{\number#2\expandafter}%
	\fi}

\foo{1}{1355}

\end{document}
``` 