### PR TITLE
Remove unneeded TODOs from gloss-lithuanian.ldf

### DIFF
--- a/tex/gloss-lithuanian.ldf
+++ b/tex/gloss-lithuanian.ldf
@@ -11,7 +11,7 @@
   hyphennames={lithuanian},
   hyphenmins={2,2},
   langtag=LTH,
-  indentfirst=true, % TODO Dokumentų rengimo taisyklių, patvirtintų Lietuvos vyriausiojo archyvaro 2011 m. liepos 4 d. įsakymu Nr. V-117, 29.1 punktą
+  indentfirst=true,
   fontsetup=true
 }
 
@@ -23,23 +23,23 @@
    \def\refname{Literatūra}%
    \def\abstractname{Santrauka}%
    \def\bibname{Literatūra}%
-   \def\chaptername{Skyrius}% TODO letter case
+   \def\chaptername{Skyrius}%
    \def\appendixname{Priedas}%
    \def\contentsname{Turinys}%
    \def\listfigurename{Iliustracijų sąrašas}%
    \def\listtablename{Lentelių sąrašas}%
    \def\indexname{Rodyklė}%
    \def\figurename{pav.}%
-   \def\tablename{lentelė}% TODO any special reason for \protect in babel?
+   \def\tablename{lentelė}%
    \def\partname{Dalis}%
    \def\enclname{Įdėta}%
    \def\ccname{Kopijos}%
    \def\headtoname{Kam}% TODO empty in babel?
    \def\pagename{puslapis}%
    \def\seename{žiūrėk}%
-   \def\alsoname{taip pat}% TODO some other variants are considered in babel?
+   \def\alsoname{taip pat}%
    \def\proofname{Įrodymas}%
-   \def\glossaryname{Terminų žodynas}% TODO some other variants are considered in babel?
+   \def\glossaryname{Terminų žodynas}%
 }
 
 \def\datelithuanian{%


### PR DESCRIPTION
Most TODOs mentioning `babel` are outdated, TODO in line 14 is not needed.