### PR TITLE
A fix for #608

### DIFF
--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -2641,8 +2641,9 @@ where \meta{type} is a supported language id type (such as ¦bcp-47¦) and \meta
 	\item Fix resetting of language specifications at the end of a local font
 	      set with \pkg{babel} legacy means (\cmd{\foreignlanguage} or \texttt{otherlanguage*}
 	      environment) (\TXI{607}).
-	\item Fix lowercasing of \cmd{\textlang}'s arguments (language tag was lowercased
-		  instead of language options) (\TXI{608}).
+	\item Fix lowercasing of \cmd{\textlang}'s first mendatory argument. 
+		  Now the casing does not change (language tag was lowercased
+		  always) (\TXI{608}).
 \end{itemize}
 
 \subsubsection*{New Features}

--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -2641,6 +2641,8 @@ where \meta{type} is a supported language id type (such as ¦bcp-47¦) and \meta
 	\item Fix resetting of language specifications at the end of a local font
 	      set with \pkg{babel} legacy means (\cmd{\foreignlanguage} or \texttt{otherlanguage*}
 	      environment) (\TXI{607}).
+	\item Fix lowercasing of \cmd{\textlang}'s arguments (language tag was lowercased
+		  instead of language options) (\TXI{608}).
 \end{itemize}
 
 \subsubsection*{New Features}

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -236,7 +236,6 @@
       \RLE
     }
   }
-  \ExplSyntaxOff
 }
 \__xpg_at_package_hook:nnn{luabidi}{package/luabidi/after}{
   \cs_gset_nopar:Nn{\polyglossia@setpardirection:n}{
@@ -1980,9 +1979,9 @@
 % where \text<alias> would cause clashes
 % (e.g., \textit)
 \newcommand\textlang[3][]{
-  \xpg@str@lowercase{\xpg@tmp@lang}{#2}
-  \__xpg_textlanguage:een {#1} {\xpg@tmp@lang} {#3}
-}%
+  \xpg@str@lowercase{\xpg@tmp@opts}{#1}
+  \__xpg_textlanguage:een {\xpg@tmp@opts} {#2} {#3}
+}
 
 % Alias to {<lang>}, but more suitable
 % for specific (esp. tag-based) aliases

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -1979,9 +1979,13 @@
 % where \text<alias> would cause clashes
 % (e.g., \textit)
 \newcommand\textlang[3][]{
-  \xpg@str@lowercase{\xpg@tmp@opts}{#1}
-  \__xpg_textlanguage:een {\xpg@tmp@opts} {#2} {#3}
+  \__xpg_textlanguage:een {#1} {#2} {#3}
 }
+
+% prevent the language tag in \textlang 
+% (second argument) from being affected
+% inside case changing commands (e.g. \MakeUppercase)
+\tl_put_right:Nn \l_text_case_exclude_arg_tl { \textlang }
 
 % Alias to {<lang>}, but more suitable
 % for specific (esp. tag-based) aliases


### PR DESCRIPTION
I'm not sure what was the intention in https://github.com/reutenauer/polyglossia/commit/d3027374d0ac2f3ddc00b067292d23983a32a9dd , but the comment says that the language options should be lowered case, not the language tag, so I think this is the correct fix. 