### PR TITLE
clean up expl3 commands in polyglossia.sty

### DIFF
--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -31,6 +31,7 @@
 \cs_generate_variant:Nn  \cs_new_nopar:Nn {Ne}
 \cs_generate_variant:Nn  \cs_gset_nopar:Npn {Npe}
 \cs_generate_variant:Nn  \cs_gset_nopar:Npn {cpe}
+\cs_generate_variant:Nn  \tl_set:Nn {Ne}
 \prg_generate_conditional_variant:Nnn \file_if_exist:n {e} {TF, T, F, p}
 \prg_generate_conditional_variant:Nnn \tl_if_blank:n {e} {TF, T, F, p}
 \prg_generate_conditional_variant:Nnn \clist_if_in:Nn {Ne} {TF, T, F}

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -31,11 +31,9 @@
 \cs_generate_variant:Nn  \cs_new_nopar:Nn {Ne}
 \cs_generate_variant:Nn  \cs_gset_nopar:Npn {Npe}
 \cs_generate_variant:Nn  \cs_gset_nopar:Npn {cpe}
-\cs_generate_variant:Nn  \tl_set:Nn {Ne}
-\cs_generate_variant:Nn  \str_foldcase:n {e}
 \prg_generate_conditional_variant:Nnn \file_if_exist:n {e} {TF, T, F, p}
 \prg_generate_conditional_variant:Nnn \tl_if_blank:n {e} {TF, T, F, p}
-\prg_generate_conditional_variant:Nnn \clist_if_in:Nn {Ne} {TF, T, F, p}
+\prg_generate_conditional_variant:Nnn \clist_if_in:Nn {Ne} {TF, T, F}
 \prg_generate_conditional_variant:Nnn \prop_if_in:Nn {Ne} {TF, T, F, p}
 % correct a bug in tracklang
 \__xpg_at_package_hook:nnn{tracklang}{file/tracklang.sty/after}{%
@@ -434,7 +432,7 @@
     #1 / language
        .value_required:n = true,
     #1 / language
-        .initial:x = {\str_upper_case:n#1},
+        .initial:x = {\str_uppercase:n#1},
     % the language tag
     #1 / langtag
        .code:n = {\prop_gput:Nnn{\polyglossia@langsetup}{#1/langtag}{##1}},


### PR DESCRIPTION
While testing a file with `\debug_on:n{all}` I noticed a few things in polyglossia.sty that are fixed in this PR.
- The command `\str_foldcase:(n|e)` is never used so there's no need to generate an `e`-variant. It's also been deprecated in favor of `\str_casefold:n`.
- There is no `\clist_if_in_p:n` command so generating a conditional variant for it does nothing.
- The command `\str_upper_case:n` was deprecated in favor of `\str_uppercase:n` in the 2020-01-03 kernel release.