### PR TITLE
fix korean when nested language is inserted without space

### DIFF
--- a/tex/gloss-korean.ldf
+++ b/tex/gloss-korean.ldf
@@ -435,7 +435,7 @@
     % \XeTeXlinebreaklocale is global,
     % so we need to reset after nested language got closed
     \def\nestedextras@korean{%
-      \XeTeXlinebreaklocale "ko"%
+      \XeTeXlinebreaklocale "ko"\relax
     }
 \else % luatex
     \def\inlineextras@korean{\xpg@attr@cjkspacing\xpg@korean@variant\relax}

--- a/tex/polyglossia-cjk-spacing.lua
+++ b/tex/polyglossia-cjk-spacing.lua
@@ -409,7 +409,9 @@ local function cjk_break (head)
                     curr, next = next, node.getnext(next)
                 end
 
-                if next and (next.id == glyph_id or next.id == math_id and next.subtype == 0) then
+                if next and node.has_attribute(next, attr_cjk)
+                    and (next.id == glyph_id or next.id == math_id and next.subtype == 0) then
+
                     local n = next.char or 0
                     f = f or next.font or 0 -- in case of curr == math_off
 


### PR DESCRIPTION
Consider this example:
```latex
\documentclass{article}
\usepackage{polyglossia}
\setmainlanguage{korean}
\setotherlanguages{english}
\newfontfamily\koreanfont{UnBatang.ttf}

\begin{document}

가나\textenglish{abc}다라.

\end{document}
```
Without the patch of this PR, Korean characters after `\textenglish{...}` disappear in the PDF generated with xelatex.
`\XeTeXlinebreaklocale` seems to work properly only when it is followed by a space or a command such as `\relax`.
Only Korean language seems to be affected by the commit 7cb75084; similar examples using Chinese or Japanese do not have disappearing tokens.

While testing the above example with lualatex, it has turned out that it is better for consistent typesetting to check the attribute of next node in  polyglossia-cjk-spacing.lua.  