### PR TITLE
[cjk] fix a bug regarding multiple CJK languages

### DIFF
--- a/testfiles/autogen/test-gloss-chinese.luatex.tlg
+++ b/testfiles/autogen/test-gloss-chinese.luatex.tlg
@@ -26,7 +26,7 @@ Package polyglossia Info: Default language is chinese
 .\TU/lmr/m/n/10 日
 .\TU/lmr/m/n/10 󰀀
 .\penalty 10000
-.\glue 0.0 plus 0.5 minus 0.1
+.\glue 0.0 plus 1.0 minus 0.1
 .\TU/lmr/m/n/10 .
 ! OK.
 <to be read again> 

--- a/testfiles/autogen/test-gloss-ja.luatex.tlg
+++ b/testfiles/autogen/test-gloss-ja.luatex.tlg
@@ -28,7 +28,7 @@ Package polyglossia Info: Default language is japanese
 .\TU/lmr/m/n/10 日
 .\TU/lmr/m/n/10 󰀀
 .\penalty 10000
-.\glue 0.0 plus 0.5 minus 0.1
+.\glue 0.0 plus 1.0 minus 0.1
 .\TU/lmr/m/n/10 .
 ! OK.
 <to be read again> 

--- a/testfiles/autogen/test-gloss-japanese.luatex.tlg
+++ b/testfiles/autogen/test-gloss-japanese.luatex.tlg
@@ -26,7 +26,7 @@ Package polyglossia Info: Default language is japanese
 .\TU/lmr/m/n/10 日
 .\TU/lmr/m/n/10 󰀀
 .\penalty 10000
-.\glue 0.0 plus 0.5 minus 0.1
+.\glue 0.0 plus 1.0 minus 0.1
 .\TU/lmr/m/n/10 .
 ! OK.
 <to be read again> 

--- a/testfiles/autogen/test-gloss-ko.tlg
+++ b/testfiles/autogen/test-gloss-ko.tlg
@@ -10,10 +10,10 @@ File: gloss-korean.ldf polyglossia: module for Korean
 (../load-unicode-xetex-classes.tex 
 load-unicode-xetex-classes.tex v... (....-..-..)
 Reading Unicode east Asian character class data
-# LineBreak-15.1.0.txt 
-# Date: ....-..-.., 13:19:22 GMT [KW] 
-# EastAsianWidth-15.1.0.txt 
-# Date: ....-..-.., 23:34:08 GMT 
+# LineBreak-16.0.0.txt 
+# Date: ....-..-.., 16:26:55 GMT 
+# EastAsianWidth-16.0.0.txt 
+# Date: ....-..-.., 21:48:20 GMT 
 )
 \XPGKOcharclassMD=\XeTeXcharclass4
 \XPGKOcharclassFS=\XeTeXcharclass5

--- a/testfiles/autogen/test-gloss-korean.tlg
+++ b/testfiles/autogen/test-gloss-korean.tlg
@@ -8,10 +8,10 @@ File: gloss-korean.ldf polyglossia: module for Korean
 (../load-unicode-xetex-classes.tex 
 load-unicode-xetex-classes.tex v... (....-..-..)
 Reading Unicode east Asian character class data
-# LineBreak-15.1.0.txt 
-# Date: ....-..-.., 13:19:22 GMT [KW] 
-# EastAsianWidth-15.1.0.txt 
-# Date: ....-..-.., 23:34:08 GMT 
+# LineBreak-16.0.0.txt 
+# Date: ....-..-.., 16:26:55 GMT 
+# EastAsianWidth-16.0.0.txt 
+# Date: ....-..-.., 21:48:20 GMT 
 )
 \XPGKOcharclassMD=\XeTeXcharclass4
 \XPGKOcharclassFS=\XeTeXcharclass5

--- a/testfiles/autogen/test-gloss-zh-CN.luatex.tlg
+++ b/testfiles/autogen/test-gloss-zh-CN.luatex.tlg
@@ -28,7 +28,7 @@ Package polyglossia Info: Default language is chinese
 .\TU/lmr/m/n/10 日
 .\TU/lmr/m/n/10 󰀀
 .\penalty 10000
-.\glue 0.0 plus 0.5 minus 0.1
+.\glue 0.0 plus 1.0 minus 0.1
 .\TU/lmr/m/n/10 .
 ! OK.
 <to be read again> 

--- a/testfiles/autogen/test-gloss-zh-TW.luatex.tlg
+++ b/testfiles/autogen/test-gloss-zh-TW.luatex.tlg
@@ -28,7 +28,7 @@ Package polyglossia Info: Default language is chinese
 .\TU/lmr/m/n/10 日
 .\TU/lmr/m/n/10 󰀀
 .\penalty 10000
-.\glue 0.0 plus 0.5 minus 0.1
+.\glue 0.0 plus 1.0 minus 0.1
 .\TU/lmr/m/n/10 .
 ! OK.
 <to be read again> 

--- a/tex/gloss-korean.ldf
+++ b/tex/gloss-korean.ldf
@@ -403,20 +403,22 @@
         \ifcase\xpg@korean@variant\relax
             \XeTeXinterchartokenstate\z@
             \XeTeXlinebreakpenalty 50
+            \XeTeXlinebreakskip 0pt plus.05em minus .01em
         \or
             \setvariantkoreaninterchartoks
             \setvariantkoreancharclasses
             \def\XPGKOhalfdim{\dimexpr.5em\relax}%
             \XeTeXinterchartokenstate\@ne
             \XeTeXlinebreakpenalty \z@
+            \XeTeXlinebreakskip 0pt plus.1em minus .01em
         \else
             \setvariantkoreaninterchartoks
             \setvariantkoreancharclasses
             \def\XPGKOhalfdim{\dimexpr.5\fontdimen\tw@\font\relax}%
             \XeTeXinterchartokenstate\@ne
             \XeTeXlinebreakpenalty 50
+            \XeTeXlinebreakskip 0pt plus.05em minus .01em
         \fi
-        \XeTeXlinebreakskip 0pt plus.05em minus .01em
         \XeTeXlinebreaklocale "ko"
     }
     \def\noextras@korean{%
@@ -459,7 +461,9 @@
     \let\newattribute\newluatexattribute
     \let\unsetattribute\unsetluatexattribute
 \fi
-\newattribute\xpg@attr@cjkspacing
+\ifdefined\xpg@attr@cjkspacing\else
+    \newattribute\xpg@attr@cjkspacing
+\fi
 \newattribute\xpg@attr@autojosa
 % user commands for Josa
 % Josa : particles in Korean grammar that immediately follow a noun or pronoun.

--- a/tex/polyglossia-cjk-spacing.lua
+++ b/tex/polyglossia-cjk-spacing.lua
@@ -380,8 +380,10 @@ local function insert_penalty_glue (head, curr, f, var, nobr, x)
     local size, glue = get_font_size(f, x and var == 2)
     if x then
         glue = get_new_glue(size/2, size/4, size/8)
-    else
+    elseif var == 0 or var == 2 then
         glue = get_new_glue(0, size/10, size/50)
+    else
+        glue = get_new_glue(0, size/5, size/50)
     end
     head, curr = node.insert_after(head, curr, glue)
     return head, curr


### PR DESCRIPTION
Consider this example:
```latex
\documentclass{article}
\usepackage{polyglossia}
\newcommand*{\teststring}{%
  子曰：「學而時習之，不亦說乎？有朋自遠方來，不亦樂乎？人不知而不慍，不亦君子乎？」
}
\setdefaultlanguage{english}
\setotherlanguages{chinese,korean}
\newfontfamily\chinesefont[Script=CJK,Language=Chinese Simplified]{Noto Sans CJK KR}
\newfontfamily\koreanfont[Script=Hangul,Language=Korean]{Noto Sans CJK KR}
\begin{document}
\textkorean[variant=classic]{\teststring}

\textchinese{\teststring}
\end{document}
```
The result has no line-break, because gloss-korean.ldf did not check whether `\xpg@attr@cjkspacing` is already defined.
This PR addresses the issue.

Incidentally, we now give a little more glue-stretchability between CJK characters in Chinese, Japanese, and classic Korean texts.
