### PR TITLE
Several corrections for Latin

### DIFF
--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -349,9 +349,9 @@ brazil             & portuguese & variant=brazilian                   \\
 british            & english    & variant=british                     \\
 canadian           & english    & variant=canadian                    \\
 canadien           & french     & variant=canadian                    \\
-classiclatin       & latin      & variant=classic                     \\
+classicallatin     & latin      & variant=classic                     \\
 farsi              & persian    &                                     \\
-ecclesiasticlatin  & latin      & variant=ecclesiastic                \\
+ecclesiasticallatin& latin      & variant=ecclesiastic                \\
 friulan            & friulian   &                                     \\
 german\footnote{Due to the name conflict only available in \pkg{polyglossia} as \emph{germanb} (which is a \pkg{babel} synonym).}
                    & german     & spelling=old                        \\
@@ -2730,6 +2730,13 @@ where \meta{type} is a supported language id type (such as ¦bcp-47¦) and \meta
 \bgroup\footnotesize
 
 \subsection*{2.5 (forthcoming)}
+
+\subsubsection*{Interface and defaults changes}
+\begin{itemize}
+	\item The babelnames ¦classiclatin¦ and ¦ecclesiasticlatin¦ are changed to
+		¦classicallatin¦ and ¦ecclesiasticallatin¦. This reflects a change in the
+		\pkg{babel-latin} package.
+\end{itemize}
 
 \subsubsection*{Bug fixes}
 \begin{itemize}

--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -2742,6 +2742,8 @@ where \meta{type} is a supported language id type (such as ¦bcp-47¦) and \meta
 \begin{itemize}
 	\item Fix a bug with linebreaking in CJK languages (\TXP{675}).
 	\item Fix global setting of \xpgoption{babelshorthands} (\TXP{680}).
+	\item Fix mapping between upper and lower case for classic and medieval
+		Latin: \emph{u/V, ú/V́, ū/V̄, ŭ/V̆}.
 \end{itemize}
 
 \subsection*{2.4 (2025/01/31)}

--- a/tex/gloss-classicallatin.ldf
+++ b/tex/gloss-classicallatin.ldf
@@ -1,6 +1,6 @@
 % Language definition file (part of polyglossia v2.4 -- 2025/01/31)
 %
-\ProvidesFile{gloss-classiclatin.ldf}[polyglossia: module for classic Latin]
+\ProvidesFile{gloss-classicallatin.ldf}[polyglossia: module for classical Latin]
 
 % We provide this as a babel alias
 

--- a/tex/gloss-classiclatin.ldf
+++ b/tex/gloss-classiclatin.ldf
@@ -1,0 +1,11 @@
+% Language definition file (part of polyglossia v2.4 -- 2025/01/31)
+%
+\ProvidesFile{gloss-classiclatin.ldf}[polyglossia: module for classical Latin]
+
+% We provide this as a babel alias
+
+\PackageWarningNoLine{polyglossia}{The language classiclatin is outdated.\MessageBreak
+Use the language classicallatin instead}
+\InheritGlossFile{latin}
+
+\endinput

--- a/tex/gloss-ecclesiasticallatin.ldf
+++ b/tex/gloss-ecclesiasticallatin.ldf
@@ -1,6 +1,6 @@
 % Language definition file (part of polyglossia v2.4 -- 2025/01/31)
 %
-\ProvidesFile{gloss-ecclesiasticlatin.ldf}[polyglossia: module for ecclesiastic Latin]
+\ProvidesFile{gloss-ecclesiasticallatin.ldf}[polyglossia: module for ecclesiastical Latin]
 
 % We provide this as a babel alias
 

--- a/tex/gloss-ecclesiasticlatin.ldf
+++ b/tex/gloss-ecclesiasticlatin.ldf
@@ -1,0 +1,11 @@
+% Language definition file (part of polyglossia v2.4 -- 2025/01/31)
+%
+\ProvidesFile{gloss-ecclesiasticlatin.ldf}[polyglossia: module for ecclesiastical Latin]
+
+% We provide this as a babel alias
+
+\PackageWarningNoLine{polyglossia}{The language ecclesiasticlatin is outdated.\MessageBreak
+Use the language ecclesiasticallatin instead}
+\InheritGlossFile{latin}
+
+\endinput

--- a/tex/gloss-la-x-classic.ldf
+++ b/tex/gloss-la-x-classic.ldf
@@ -1,6 +1,6 @@
 % Language definition file (part of polyglossia v2.4 -- 2025/01/31)
 %
-\ProvidesFile{gloss-la-xclassic.ldf}[polyglossia: module for la-xclassic (Latin)]
+\ProvidesFile{gloss-la-x-classic.ldf}[polyglossia: module for la-x-classic (Latin)]
 
 % We provide this as a bcp47-compliant alias
 

--- a/tex/gloss-la-x-ecclesia.ldf
+++ b/tex/gloss-la-x-ecclesia.ldf
@@ -1,6 +1,6 @@
 % Language definition file (part of polyglossia v2.4 -- 2025/01/31)
 %
-\ProvidesFile{gloss-la-xecclesiastic.ldf}[polyglossia: module for la-xecclesiastic (Latin)]
+\ProvidesFile{gloss-la-x-ecclesia.ldf}[polyglossia: module for la-x-ecclesia (Latin)]
 
 % We provide this as a bcp47-compliant alias
 

--- a/tex/gloss-la-x-medieval.ldf
+++ b/tex/gloss-la-x-medieval.ldf
@@ -1,6 +1,6 @@
 % Language definition file (part of polyglossia v2.4 -- 2025/01/31)
 %
-\ProvidesFile{gloss-la-xmedieval.ldf}[polyglossia: module for la-xmedieval (Latin)]
+\ProvidesFile{gloss-la-x-medieval.ldf}[polyglossia: module for la-x-medieval (Latin)]
 
 % We provide this as a bcp47-compliant alias
 

--- a/tex/gloss-latin.ldf
+++ b/tex/gloss-latin.ldf
@@ -21,8 +21,8 @@
 \setlanguagealias*[variant=medieval]{latin}{la-x-medieval}
 
 % Babel aliases
-\setlanguagealias[variant=classic]{latin}{classiclatin}
-\setlanguagealias[variant=ecclesiastic]{latin}{ecclesiasticlatin}
+\setlanguagealias[variant=classic]{latin}{classicallatin}
+\setlanguagealias[variant=ecclesiastic]{latin}{ecclesiasticallatin}
 \setlanguagealias[variant=medieval]{latin}{medievallatin}
 
 
@@ -386,7 +386,7 @@
     \bool_set_true:N \l_polyglossia_latin_capitalize_month_bool
     \bool_set_false:N \l_polyglossia_latin_punctuation_spacing_bool
     \str_set:Nn \l_polyglossia_latin_variant_str {classic}
-    \SetLanguageKeys {latin} { babelname = classiclatin, bcp47 = la-x-classic, bcp47-extension-x = classic }
+    \SetLanguageKeys {latin} { babelname = classicallatin, bcp47 = la-x-classic, bcp47-extension-x = classic }
     \polyglossia_latin_set_patterns:n {classiclatin}
   }
 
@@ -422,7 +422,7 @@
     \bool_set_false:N \l_polyglossia_latin_capitalize_month_bool
     \bool_set_true:N \l_polyglossia_latin_punctuation_spacing_bool
     \str_set:Nn \l_polyglossia_latin_variant_str {ecclesiastic}
-    \SetLanguageKeys {latin} { babelname = ecclesiasticlatin, bcp47 = la-x-ecclesia, bcp47-extension-x = ecclesia }
+    \SetLanguageKeys {latin} { babelname = ecclesiasticallatin, bcp47 = la-x-ecclesia, bcp47-extension-x = ecclesia }
     \polyglossia_latin_use_modern_patterns:
   }
 

--- a/tex/gloss-latin.ldf
+++ b/tex/gloss-latin.ldf
@@ -36,24 +36,16 @@
 \bool_new:N \l_polyglossia_latin_prosodic_shorthands_bool
 \bool_new:N \l_polyglossia_latin_ecclesiastic_footnotes_bool
 
-\cs_new:Npn \polyglossia_latin_classical_character_codes:
-  {
-    \char_set_lccode:nn {`\V} {`\u}
-    \char_set_uccode:nn {`\u} {`\V}
-    \char_set_uccode:nn {`\ú} {`\V}
-    \char_set_uccode:nn {`\ū} {`\V}
-    \char_set_uccode:nn {`\ŭ} {`\V}
-  }
-
-\cs_new:Npn \polyglossia_latin_modern_character_codes:
-  {
-    \char_set_lccode:nn {`\V} {`\v}
-    \char_set_uccode:nn {`\u} {`\U}
-    \char_set_uccode:nn {`\ú} {`\Ú}
-    \char_set_uccode:nn {`\ū} {`\Ū}
-    \char_set_uccode:nn {`\ŭ} {`\Ŭ}
-  }
-
+\DeclareUppercaseMapping[la-x-classic]{`u}{V}
+\DeclareLowercaseMapping[la-x-classic]{`V}{u}
+% The mapping of u and V for medieval Latin is part of the l3text module,
+% which is part of the LaTeX format (see source3.pdf).
+\DeclareUppercaseMapping[la-x-classic]{`ú}{\a'{V}}
+\DeclareUppercaseMapping[la-x-classic]{`ū}{\a={V}}
+\DeclareUppercaseMapping[la-x-classic]{`ŭ}{\u{V}}
+\DeclareUppercaseMapping[la-x-medieval]{`ú}{\a'{V}}
+\DeclareUppercaseMapping[la-x-medieval]{`ū}{\a={V}}
+\DeclareUppercaseMapping[la-x-medieval]{`ŭ}{\u{V}}
 
 %%%%% Messages and commands concerning hyphenation
 
@@ -386,7 +378,7 @@
     \bool_set_true:N \l_polyglossia_latin_capitalize_month_bool
     \bool_set_false:N \l_polyglossia_latin_punctuation_spacing_bool
     \str_set:Nn \l_polyglossia_latin_variant_str {classic}
-    \SetLanguageKeys {latin} { babelname = classicallatin, bcp47 = la-x-classic, bcp47-extension-x = classic }
+    \SetLanguageKeys {latin} { babelname = classicallatin, bcp47 = la-x-classic, bcp47-extension-x = classic, bcp47-casing = la-x-classic }
     \polyglossia_latin_set_patterns:n {classiclatin}
   }
 
@@ -1018,15 +1010,10 @@
      }
     \xpgla@savedvalues
     \polyglossia_latin_no_punctuation_spacing:
-    \polyglossia_latin_modern_character_codes:
   }
 
 \cs_new:Npn \polyglossia_latin_inline_extras:
   {
-    \bool_if:NF \l_polyglossia_latin_use_v_bool
-      {
-        \polyglossia_latin_classical_character_codes:
-      }
     \bool_if:NT \l_polyglossia_latin_punctuation_spacing_bool
       {
         \polyglossia_latin_punctuation_spacing:

--- a/tex/gloss-latin.ldf
+++ b/tex/gloss-latin.ldf
@@ -22,7 +22,9 @@
 
 % Babel aliases
 \setlanguagealias[variant=classic]{latin}{classicallatin}
+\setlanguagealias[variant=classic]{latin}{classiclatin}
 \setlanguagealias[variant=ecclesiastic]{latin}{ecclesiasticallatin}
+\setlanguagealias[variant=ecclesiastic]{latin}{ecclesiasticlatin}
 \setlanguagealias[variant=medieval]{latin}{medievallatin}
 
 

--- a/tex/gloss-latin.ldf
+++ b/tex/gloss-latin.ldf
@@ -509,8 +509,8 @@
     prosodicshorthands.default:n = true,
     usej.bool_set:N = \l_polyglossia_latin_use_j_bool,
     capitalizemonth.bool_set:N = \l_polyglossia_latin_capitalize_month_bool,
-    hyphenation.code = 
-    	\str_case:nnTF {#1}
+    hyphenation.code =
+      \str_case:nnTF {#1}
       {
         {classic}    { \polyglossia_latin_set_patterns:n {classiclatin} }
         {liturgical} { \polyglossia_latin_set_patterns:n {liturgicallatin} }
@@ -522,8 +522,8 @@
       {
         \msg_warning:nnn {polyglossia} {latin / illegal hyphenation variant} {#1}
       },
-    variant.code = 
-    	  \str_case:nnF {#1}
+    variant.code =
+      \str_case:nnF {#1}
       {
         {classic}
         {
@@ -550,7 +550,7 @@
         \msg_warning:nnn {polyglossia} {latin / illegal language variant} {#1}
       },
     ecclesiasticfootnotes.choices:nn = { true, false }
-      { 
+      {
         \ifcase\UseName{l_keys_choice_int}\or
            \bool_set_true:N \l_polyglossia_latin_ecclesiastic_footnotes_bool
         \else
@@ -1010,28 +1010,36 @@
      }
     \xpgla@savedvalues
     \polyglossia_latin_no_punctuation_spacing:
+    \bool_if:NF \l_polyglossia_latin_use_v_bool
+      {
+        \char_set_lccode:nn {`\V} {`\v}
+      }
   }
 
 \cs_new:Npn \polyglossia_latin_inline_extras:
   {
+    \bool_if:NF \l_polyglossia_latin_use_v_bool
+      {
+        \char_set_lccode:nn {`\V} {`\u}
+      }
     \bool_if:NT \l_polyglossia_latin_punctuation_spacing_bool
       {
         \polyglossia_latin_punctuation_spacing:
       }
     \bool_if:NTF \l_polyglossia_latin_babelshorthands_bool
-     {
-      \polyglossia_latin_shorthands:
-     }
-     {
-      \polyglossia_latin_no_shorthands:
-     }
+      {
+        \polyglossia_latin_shorthands:
+      }
+      {
+        \polyglossia_latin_no_shorthands:
+      }
     \bool_if:NTF \l_polyglossia_latin_prosodic_shorthands_bool
-     {
-      \polyglossia_latin_prosodic_shorthands:
-     }
-     { 
-      \polyglossia_latin_no_prosodic_shorthands:
-     }
+      {
+        \polyglossia_latin_prosodic_shorthands:
+      }
+      {
+        \polyglossia_latin_no_prosodic_shorthands:
+      }
   }
 
 \def \blockextras@latin
@@ -1059,7 +1067,7 @@
 
 %%   Copyright (C) Claudio Beccari 2013-2016
 %%   Copyright (C) Élie Roux 2016-2019
-%%   Copyright (C) Keno Wehr 2019-2022
+%%   Copyright (C) Keno Wehr 2019-2025
 %%
 %%   Permission is hereby granted, free of charge, to any person obtaining
 %%   a copy of this software and associated documentation files

--- a/tex/polyglossia.sty
+++ b/tex/polyglossia.sty
@@ -770,7 +770,7 @@
 \cs_new_nopar:Nn \__xpg_no_gloss:n
   {
     \xpg_warning_msg:n
-       {File~ gloss-#1.ldf~ do~ not~  exists! \iow_newline:
+       {File~ gloss-#1.ldf~ does~ not~ exist! \iow_newline:
         I~ will~ nevertheless~ try~ to~ use~ hyphenation~ patterns~ for~ #1.}
 
     \PolyglossiaSetup{#1}{hyphennames={#1}}


### PR DESCRIPTION
The newest version 4.1 of babel-latin has replaced classiclatin and ecclesiasticlatin by classicallatin and ecclesiasticallatin for the sake of philological correctness. Furthermore, the mapping between lower case u and upper case V for classic and medieval Latin needs a correction.