### PR TITLE
allow linebreak between non-glyph box and CJK char

### DIFF
--- a/doc/polyglossia.tex
+++ b/doc/polyglossia.tex
@@ -2739,6 +2739,14 @@ where \meta{type} is a supported language id type (such as ¦bcp-47¦) and \meta
 
 \bgroup\footnotesize
 
+\subsection*{2.9 (Forthcoming)}
+
+\subsubsection*{Bug fixes}
+\begin{itemize}
+  \item Allow linebreak between a non-glyph box and CJK characters (\TXI{690}).
+        This fix partly retores the functionality of v.\,2.7.
+\end{itemize}
+
 \subsection*{2.8 (2025/09/22)}
 
 \subsubsection*{Bug fixes}


### PR DESCRIPTION
Allow linebreak between non-glyph box and CJK character (restore the concept of v2.7).
And tidy up the code in cjk_break function.

This PR is not an urgent update.
